### PR TITLE
Add ReadMe.md files to describe the content of the open sourced folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ instructions for macOS and Ubuntu.
   brew install node doxygen
   ```
 
-### Install build tools & libraries (Linux)
+### Install build tools & libraries (Ubuntu)
+
+_These instructions are validated using Ubuntu 20.04, whereas Ubuntu 18.04
+doesn't install recent enough versions of cmake, fmt, lz4, and zstd._
 
 - install tools & libraries:
   ```
@@ -168,7 +171,7 @@ are provided. We are working on open sourcing more code:
 - `VRSplayer`: a basic "player", to view VRS file like multi-stream video files.
 - `pyvrs`: a Python library to work with VRS files in Python.
 - integration with PyTorch, so ML jobs can consume VRS files as training data.
-- tooling to build VRS container files optimized for PyTorch traning.
+- tooling to build VRS container files optimized for PyTorch training.
 - video codec compression support.
 - building blocks to implement network streaming.
 

--- a/cmake/ReadMe.md
+++ b/cmake/ReadMe.md
@@ -1,0 +1,5 @@
+# What is in this folder?
+
+The files in this folder are complementary cmake files required by the cmake
+system to find additional libraries VRS depend on, as well as define useful
+definitions and helper cmake definitions.

--- a/sample_apps/ReadMe.md
+++ b/sample_apps/ReadMe.md
@@ -1,0 +1,9 @@
+# What is in this folder?
+
+The code in this folder demonstrates how to use the VRS API.
+
+- `SampleRecordingApp.cpp`: Shows how to create a file with some made-up data.
+- `SamplePlaybackApp.cpp`: Shows how to read the file created by
+  `SampleRecordingApp.cpp`, and verify its content.
+- `SampleConfigRecordsReaderApp.cpp`: Shows how to extract a specific piece of
+  data from a specific record.

--- a/sample_code/ReadMe.md
+++ b/sample_code/ReadMe.md
@@ -1,0 +1,9 @@
+# What is in this folder?
+
+The code in this folder demonstrates how to use the VRS API, but it doesn't
+actually do anything useful, or show complete functionality.
+
+- `SampleImageReader.cpp`: Demonstrates how to read the images in a file.
+- `SampleRecordAndPlay.cpp`: Demonstrates how to create and read a VRS file.
+- `SampleRecordFormatDataLayout.cpp`: Demonstrates how to create and read
+  records using `RecordFormat` and `DataLayout`.

--- a/vrs/ReadMe.md
+++ b/vrs/ReadMe.md
@@ -1,0 +1,108 @@
+# What is in this folder?
+
+The code in this folder implements VRS' core functionality, and only the core
+functionality, in a flat structure. Rather than having a strict model with one
+class per cpp/h pair, which quickly leads to a huge number of files, VRS might
+define multiple related minor and small classes in the same cpp/h pair.
+
+The following classification of headers is designed to help new users navigate
+the code and focus on the pieces they are interested in, separating the class
+they will want to use from the implementation layers, that users of VRS should
+never need to even look at. You are virtually guaranteed to directly create or
+interact with the top ones, but should probably never need to even look as the
+last ones in the list.
+
+## Reading VRS Files
+
+- `RecordFileReader.h`: `RecordFileReader`, to open and read VRS files.
+- `RecordFormatStreamPlayer.h`: `RecordFormatStreamPlayer`, to receive data from
+  read records using `RecordFormat` and `DataLayout`.
+- `StreamId.h`: `StreamId`, to identify the streams in a file.
+- `MultiRecordFileReader.h`: `MultiRecordFileReader`, to read multiple related
+  VRS files at once. (Advanced use case, when a single recording was split into
+  multiple files).
+- `DataReference.h`: `DataReference` to tell when read data should be written
+  and avoid unnecessary data copies.
+
+## Writing VRS Files
+
+- `RecordFileWriter.h`: `RecordFileWriter`, to create new VRS files.
+- `Recordable.h`: `Recordable`, to create a stream in a `RecordFileWriter`.
+- `DataSource.h`: `DataSource` and associated classes, to specify where the data
+  of a new record is found.
+
+## Representing Data in Records
+
+- `RecordFormat.h`: `RecordFormat`, to specify how a record is structured in
+  `ContentBlock` parts.
+- `DataLayout.h`: `DataLayout`, to manage datalayout content blocks.
+- `DataPieces.h`, `DataPieceArray.h`, `DataPieceString.h`,
+  `DataPieceStringMap.h`, `DataPieceTypes.h`, `DataPieceValue.h`,
+  `DataPieceVector.h`: `DataPiece` types, the element parts that constitute a
+  `DataLayout`.
+- `DataLayoutConventions.h`: Definitions that constitute the "datalayout
+  conventions", that make `RecordFormat` and `DataLayout` work.
+- `TagConventions.h`: Definitions of file and stream tag conventions.
+
+## File Operation Helpers
+
+- `FileHandler.h`: `FileHandler` abstract interface, to read files without any
+  operating system details knowledge.
+- `FileHandlerFactory.h`: `FileHandlerFactory`, to handle `FileHandler`
+  creation.
+- `DiskFile.h`: `DiskFile`, to read local files, VRS or not.
+- `WriteFileHandler.h`: `WriteFileHandler` abstract interface, to write files in
+  different places.
+- `NewChunkHandler.h`: `NewChunkHandler`, to be notified when a new VRS file
+  chunk is created.
+- `ErrorCode.h`: Helpers to handle error codes from unrelated modules.
+- `FileCache.h`, `FileDetailsCache.h`: Helper infra, to cache data when
+  accessing cloud storage in particular.
+- `TelemetryLogger.h`: `TelemetryLogger`, for usage telemetry. The open source
+  implementation doesn't implement any actual telemetry, and merely writes
+  messages to the log output.
+
+## Misc Helpers
+
+- `Record.h`: `Record`, used when creating data.
+- `RecordManager.h`: `RecordManager`, to manage a `Recordable` object's `Record`
+  objects during file creation.
+- `StreamPlayer.h`: `StreamPlaer`, the base class defining core callbacks when
+  reading records.
+- `ContentBlockReader.h`: `ContentBlockReader` and associates, to read
+  `ContentBlock` parts.
+- `RecordReaders.h`: `RecordReader`, to read data from a record, losslessly
+  compressed or not.
+- `Compressor.h`: `Compressor`, to losslessly compress data.
+- `Decompressor.h`: `Decompressor`, to read losslessly compressed data.
+- `ForwardDefinitions.h`: Forward definition, to help limit header includes.
+- `LegacyFormatsProvider.h`: `LegacyFormatsProvider` to make it possible to read
+  files created before the introduction of `RecordFormat` and `DataLayout` using
+  `RecordFormat` and `DataLayout`.  
+  Hopefully never needed in open source use cases!
+- `ProgressLogger.h`: `ProgressLogger` to track progress when opening a file.
+  Probably only needed with handling files in cloud storage.
+
+## File Format Core Internal
+
+These are the building blocks that define that actual VRS file format. Note that
+there is no VRS file format specification document, in part to discourage the
+temptation to re-implement the spec to support another language. Instead, please
+build language bindings that rely on this open source C++ implementation. How
+VRS files actually look like is not locked down intentionally, so that we can
+make the file format evolve as radically and often as we might need.
+
+- `FileFormat.h`: `FileHeader` and `RecordHeader`, to hold data describing VRS
+  files and VRS records.
+- `IndexRecord.h`: To read and write VRS index records, which contain the VRS
+  file's index.
+- `DescriptionRecord.h`: To read and write description records, which contain
+  the VRS file's metadata, including all the file and stream tags, including
+  `RecordFormat` and `DataLayout` definitions.
+- `TagsRecord.h`: To read and write tag records, needed when streams are created
+  after the file was initially created.
+
+In effect, the VRS file format is defined by the definitions found in
+`FileFormat.h`, `IndexRecord.h`, `DescriptionRecord.h`, `TagsRecord.h`, but also
+`RecordFormat.h`, `DataLayout.h` and associated `DataPiece` objects,
+`DataLayoutConventions.h`, using json, lz4, and zstd.

--- a/vrs/helpers/ReadMe.md
+++ b/vrs/helpers/ReadMe.md
@@ -1,0 +1,5 @@
+# What is in this folder?
+
+The classes in this folder provide various helper functionality, not
+fundamentally tied to anything specifically "VRS", but that were designed
+specifically to help write VRS.

--- a/vrs/os/ReadMe.md
+++ b/vrs/os/ReadMe.md
@@ -1,0 +1,16 @@
+# What is in this folder?
+
+The `vrs/os` module provides a number of operating system abstractions. It
+exists in part because `std::filesystem` is in its infancy. While
+`std::filesystem` has made great progress recently, it still has teething
+issues, and worse, it is still not available on every system we need VRS to
+support.
+
+For open source targets, `vrs/os` mostly relies on boost, which provides the
+most robust and complete implementation.
+
+Even after a robust version of `std::filesystem` is broadly available on common
+platforms and we can stop depending on boost, we will continue to rely on
+`vrs/os` to help build support for VRS in more challenging environments/emerging
+operating systems, where support will be slow to come, if it ever does, even for
+boost.

--- a/vrs/oss/ReadMe.md
+++ b/vrs/oss/ReadMe.md
@@ -1,0 +1,20 @@
+# What is in this folder?
+
+The modules in `vrs/oss` are replacements for libraries that exist at Meta but
+we aren't open sourcing at this point.
+
+- `vrs/oss/aria` provides `DataLayout` definitions used by the Aria device.
+- `vrs/oss/logging` provides a logging facility, that merely prints to `stdout`.
+  When integrating VRS in your own code, you will probably want to redirect that
+  logging output to your own logging infrastructure.
+
+The other modules in `vrs/oss` may look a bizarre, because they are minimized
+clones of the original, sometimes with a single definition. They are only used
+for testing.
+
+- `vrs/oss/portability` provides a single definition used for some tests only,
+  and that weren't promoted into `vrs/os`.
+- `vrs/oss/test_data` provides some sample files used for unit tests purposes
+  only.
+- `vrs/oss/test_helpers` and `vrs/oss/TestDataDir` provides helper functionality
+  for unit tests.

--- a/vrs/test/ReadMe.md
+++ b/vrs/test/ReadMe.md
@@ -1,0 +1,3 @@
+# What is in this folder?
+
+Unit tests covering VRS core functionality.

--- a/vrs/utils/xxhash/ReadMe.md
+++ b/vrs/utils/xxhash/ReadMe.md
@@ -1,0 +1,4 @@
+# What is in this folder?
+
+This helper module offers xxhash functionality in a C++ wrapper optimized for
+the VRS use cases.

--- a/website/docs/FileCreation.md
+++ b/website/docs/FileCreation.md
@@ -9,7 +9,7 @@ To create a VRS file:
 - Create as many [`Recordable`](https://github.com/facebookresearch/vrs/blob/main/vrs/Recordable.h) objects as needed, one per _device_. Each Recordable object will create a stream of records for itself. Recordables do not need to be aware of either the file writer or any other Recordables.
 - Add tags to the file writer and the Recordables as necessary to describe your devices and setup. Add things such as serial numbers, global configuration settings, user names, locations, user heights, etc. Make sure you capture all the context you will need when you play back the VRS file.
 
-- The follwing best practices are extremely important:
+- The following best practices are extremely important:
 
   - Use the tag name conventions defined in [`<VRS/TagConventions.h>`](https://github.com/facebookresearch/vrs/blob/main/vrs/TagConventions.h) as much as possible.
   - Capture all the tags upfront, in case the recording is interrupted (out of disk space or crashes).
@@ -18,9 +18,9 @@ To create a VRS file:
 - Have your Recordables start to produce records, by calling [`Recordable::createRecord()`](https://github.com/facebookresearch/vrs/blob/main/vrs/Recordable.h#L236) as needed, from any thread. Create a record when an IMU packet is received, or an image is received from a camera. Recordables do not need to know when recording is active. They just need to produce records as often as necessary, all the time.
 
 <!-- prettier-ignore -->
-  :::note
-  *Every record has a timestamp (a `double` count of seconds), and the records of all the Recordables must use the **same time domain**, as records will be sorted based on their timestamp!*
-  :::
+:::note
+*Every record has a timestamp (a `double` count of seconds), and the records of all the Recordables must use the **same time domain**, as records will be sorted based on their timestamp!*
+:::
 
 - Tell the file writer how often to discard "old" records, and what "old" actually means.
 - Tell the file writer when to start recording. Older records will be discarded. Newer records will start to be compressed (by default) and written to disk in realtime in a background thread.

--- a/website/docs/Organization.md
+++ b/website/docs/Organization.md
@@ -14,7 +14,7 @@ The VRS documentation has different parts:
     cd <vrs_repo_top_level_folder>
     doxygen vrs/Doxyfile
   ```
-  You'll find the API documention in html at `website/static/doxygen/index.html`.
+  You'll find the API documentation in html at `website/static/doxygen/index.html`.
 - [Sample code](https://github.com/facebookresearch/vrs/tree/main/sample_code), which is not functional, but demonstrates how to use the APIs.
   - [SampleRecordAndPlay.cpp](https://github.com/facebookresearch/vrs/blob/main/sample_code/SampleRecordAndPlay.cpp) demonstrates different ways to create a file, by dumping the whole content from memory to disk after creating all the records in memory, or by writing the record to disk while continuing to create records.
   - [SampleImageReader.cpp](https://github.com/facebookresearch/vrs/blob/main/sample_code/SampleImageReader.cpp) demonstrates how to read typical image records, that is, records containing metadata and an image.

--- a/website/docs/RecordFormat.md
+++ b/website/docs/RecordFormat.md
@@ -187,7 +187,7 @@ The name of each field in the `DataLayoutStruct` is prepended by the name of the
 Effectively, the declaration above creates the same `DataPiece` fields and the same datalayout definition as the datalayout definition below, which requires different member variable names to avoid conflicts at the struct level:
 
 ```cpp
-struct MyDataLayou t: public AutoDataLayout {
+struct MyDataLayout: public AutoDataLayout {
   DataPieceVector<vrs::Matrix4Dd> leftHandOrientation{"left_hand/orientation"};
   DataPieceVector<vrs::Matrix3Dd> leftHandTranslation{"left_hand/translation"};
   DataPieceVector<vrs::Matrix4Dd> rightHandOrientation{"right_hand/orientation"};
@@ -238,7 +238,7 @@ When reading a file, you can try to use the appropriate constructor, or you can 
 
 ### Image, Audio, and Custom Content Blocks
 
-Image, audio, and custom content blocks directly contain their payload, and no additional metadata. In some cases, such as for `image/jpg` or `image/png` data, no other information is needed to interpret the data. In other cases, such with `images/raw` images, which are raw pixel buffers, image dimensions, pixel format and possibly stride information are required to know how to interpret the image content block. If that informaton never changes, it may provided directly in the `RecordFormat` definition, otherwise, it might need to be provided in a configuration record, or in the data records themselves, using what we call the Datalayout Conventions.
+Image, audio, and custom content blocks directly contain their payload, and no additional metadata. In some cases, such as for `image/jpg` or `image/png` data, no other information is needed to interpret the data. In other cases, such with `images/raw` images, which are raw pixel buffers, image dimensions, pixel format and possibly stride information are required to know how to interpret the image content block. If that information never changes, it may provided directly in the `RecordFormat` definition, otherwise, it might need to be provided in a configuration record, or in the data records themselves, using what we call the Datalayout Conventions.
 
 <Tabs>
   <TabItem value="example_1" label="Image Content Block Examples" default>
@@ -259,7 +259,7 @@ Please refer to the Image Support section for more details on how to manage imag
 ```cpp
 ContentBlock(ContentType::AUDIO); // Audio content block, without any detail
 ContentBlock(AudioFormat::PCM); // PCM audio data
-ContentBlock(AudioSampleFormat::S16_LE, 2, 48000); // PCM audio data, int16 little endian samples, 2 channels, 48 Khz
+ContentBlock(AudioSampleFormat::S16_LE, 2, 48000); // PCM audio data, int16 little endian samples, 2 channels, 48 kHz
 ```
 
 Audio blocks are analog to image blocks, and are handled the same way.


### PR DESCRIPTION
Summary: When you first discover the VRS code, it can be difficult to understand which code is important, which isn't. These ReadMe.md files are meant to help open source readers to navigate the source tree more effectively.

Differential Revision: D33242900

