### PR TITLE
Add FilteredFileReader

### DIFF
--- a/vrs/utils/CMakeLists.txt
+++ b/vrs/utils/CMakeLists.txt
@@ -14,6 +14,10 @@
 
 add_library(vrs_utils
   STATIC
+    FilterCopyHelpers.cpp
+    FilterCopyHelpers.h
+    FilteredFileReader.cpp
+    FilteredFileReader.h
     RecordFileInfo.cpp
     RecordFileInfo.h
 )

--- a/vrs/utils/FilterCopyHelpers.cpp
+++ b/vrs/utils/FilterCopyHelpers.cpp
@@ -1,0 +1,238 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "FilterCopyHelpers.h"
+
+#define DEFAULT_LOG_CHANNEL "FilterCopyHelpers"
+#include <logging/Log.h>
+
+#include <vrs/RecordFileReader.h>
+#include <vrs/RecordFileWriter.h>
+
+using namespace std;
+using namespace vrs;
+
+namespace vrs::utils {
+
+const Record* Writer::createStateRecord() {
+  return nullptr;
+}
+
+const Record* Writer::createConfigurationRecord() {
+  return nullptr;
+}
+
+const Record* Writer::createRecord(const CurrentRecord& record, vector<int8_t>& data) {
+  return Recordable::createRecord(
+      record.timestamp, record.recordType, record.formatVersion, DataSource(data));
+}
+
+const Record* Writer::createRecord(const CurrentRecord& record, DataSource& source) {
+  return Recordable::createRecord(
+      record.timestamp, record.recordType, record.formatVersion, source);
+}
+
+const Record*
+Writer::createRecord(double timestamp, Record::Type type, uint32_t formatVersion, DataSource& src) {
+  return Recordable::createRecord(timestamp, type, formatVersion, src);
+}
+
+void TagOverrides::overrideTags(RecordFileWriter& writer) const {
+  writer.addTags(fileTags);
+  if (!streamTags.empty()) {
+    for (Recordable* recordable : writer.getRecordables()) {
+      auto iter = streamTags.find(recordable->getStreamId());
+      if (iter != streamTags.end()) {
+        recordable->addTags(iter->second);
+      }
+    }
+  }
+}
+
+Copier::Copier(
+    RecordFileReader& fileReader,
+    RecordFileWriter& fileWriter,
+    StreamId id,
+    const CopyOptions& copyOptions)
+    : writer_(id.getTypeId(), fileReader.getFlavor(id)),
+      fileWriter_{fileWriter},
+      options_{copyOptions} {
+  fileReader.setStreamPlayer(id, this);
+  fileWriter.addRecordable(&writer_);
+  // copy the tags of that stream
+  writer_.addTags(fileReader.getTags(id));
+  writer_.setCompression(options_.getCompression());
+}
+
+bool Copier::processRecordHeader(const CurrentRecord& record, DataReference& outDataRef) {
+  rawRecordData_.resize(record.recordSize);
+  outDataRef.useRawData(rawRecordData_.data(), record.recordSize);
+  return true;
+}
+
+void Copier::processRecord(const CurrentRecord& record, uint32_t /*bytesWrittenCount*/) {
+  writer_.createRecord(record, rawRecordData_);
+  ++options_.outRecordCopiedCount;
+}
+
+ContentChunk::ContentChunk(DataLayout& layout) {
+  buffer_.resize(layout.getFixedData().size() + layout.getVarData().size());
+  uint8_t* buffer = buffer_.data();
+  DataSourceChunk fixedSizeChunk(layout.getFixedData());
+  fixedSizeChunk.fillAndAdvanceBuffer(buffer);
+  DataSourceChunk varSizeChunk(layout.getVarData());
+  varSizeChunk.fillAndAdvanceBuffer(buffer);
+}
+
+void ContentChunk::fillAndAdvanceBuffer(uint8_t*& buffer) const {
+  DataSourceChunk dataSourceChunk(buffer_);
+  dataSourceChunk.fillAndAdvanceBuffer(buffer);
+}
+
+ContentBlockChunk::ContentBlockChunk(const ContentBlock& contentBlock, const CurrentRecord& record)
+    : ContentChunk(contentBlock.getBlockSize()), contentBlock_{contentBlock} {
+  int status = record.reader->read(getBuffer());
+  if (status != 0) {
+    XR_LOGW("Failed to read image block: {}", errorCodeToMessage(status));
+  }
+}
+
+ContentBlockChunk::ContentBlockChunk(const ContentBlock& contentBlock, vector<uint8_t>&& buffer)
+    : ContentChunk(move(buffer)), contentBlock_{contentBlock} {}
+
+void FilteredChunksSource::copyTo(uint8_t* buffer) const {
+  for (auto& chunk : chunks_) {
+    chunk->fillAndAdvanceBuffer(buffer);
+  }
+}
+
+size_t FilteredChunksSource::getFilteredChunksSize(const deque<unique_ptr<ContentChunk>>& chunks) {
+  size_t total = 0;
+  for (auto& chunk : chunks) {
+    total += chunk->filterBuffer();
+  }
+  return total;
+}
+
+RecordFilterCopier::RecordFilterCopier(
+    RecordFileReader& fileReader,
+    RecordFileWriter& fileWriter,
+    StreamId id,
+    const CopyOptions& copyOptions)
+    : writer_(id.getTypeId(), fileReader.getFlavor(id)),
+      fileWriter_{fileWriter},
+      options_{copyOptions} {
+  fileReader.setStreamPlayer(id, this);
+  fileWriter.addRecordable(&writer_);
+  // copy the tags of that stream
+  writer_.addTags(fileReader.getTags(id));
+  writer_.setCompression(options_.getCompression());
+}
+
+bool RecordFilterCopier::processRecordHeader(const CurrentRecord& rec, DataReference& outDataRef) {
+  copyVerbatim_ = (rec.recordSize == 0) || shouldCopyVerbatim(rec);
+  skipRecord_ = false;
+  if (copyVerbatim_) {
+    verbatimRecordData_.resize(rec.recordSize);
+    outDataRef.useRawData(verbatimRecordData_.data(), rec.recordSize);
+    return true;
+  } else {
+    return RecordFormatStreamPlayer::processRecordHeader(rec, outDataRef);
+  }
+}
+
+void RecordFilterCopier::processRecord(const CurrentRecord& record, uint32_t readSize) {
+  if (!copyVerbatim_) {
+    // Read all the parts, which will result in multiple onXXXRead() callbacks
+    chunks_.clear();
+    RecordFormatStreamPlayer::processRecord(record, readSize);
+  }
+  finishRecordProcessing(record);
+  ++options_.outRecordCopiedCount;
+}
+
+void RecordFilterCopier::finishRecordProcessing(const CurrentRecord& record) {
+  if (!skipRecord_) {
+    if (copyVerbatim_) {
+      writer_.createRecord(record, verbatimRecordData_);
+    } else {
+      // filter & flush the collected data, in the order collected
+      FilteredChunksSource chunkedSource(chunks_);
+      CurrentRecord modifiedHeader(record);
+      doHeaderEdits(modifiedHeader);
+      writer_.createRecord(modifiedHeader, chunkedSource);
+    }
+  }
+}
+
+bool RecordFilterCopier::onDataLayoutRead(const CurrentRecord& rec, size_t index, DataLayout& dl) {
+  vector<int8_t> fixedData = dl.getFixedData();
+  vector<int8_t> varData = dl.getVarData();
+  dl.stageCurrentValues();
+  doDataLayoutEdits(rec, index, dl);
+  pushDataLayout(dl);
+  // restore datalayout state, so decoding the file isn't affected
+  fixedData.swap(dl.getFixedData());
+  varData.swap(dl.getVarData());
+  return true;
+}
+
+bool RecordFilterCopier::onImageRead(const CurrentRecord& rec, size_t idx, const ContentBlock& cb) {
+  size_t blockSize = cb.getBlockSize();
+  if (blockSize == ContentBlock::kSizeUnknown) {
+    return onUnsupportedBlock(rec, idx, cb);
+  }
+  unique_ptr<ContentBlockChunk> imageChunk = make_unique<ContentBlockChunk>(cb, rec);
+  filterImage(rec, idx, cb, imageChunk->getBuffer());
+  chunks_.emplace_back(move(imageChunk));
+  return true;
+}
+
+bool RecordFilterCopier::onAudioRead(const CurrentRecord& rec, size_t idx, const ContentBlock& cd) {
+  size_t blockSize = cd.getBlockSize();
+  if (blockSize == ContentBlock::kSizeUnknown) {
+    return onUnsupportedBlock(rec, idx, cd);
+  }
+  unique_ptr<ContentBlockChunk> audioChunk = make_unique<ContentBlockChunk>(cd, rec);
+  filterAudio(rec, idx, cd, audioChunk->getBuffer());
+  chunks_.emplace_back(move(audioChunk));
+  return true;
+}
+
+bool RecordFilterCopier::onUnsupportedBlock(
+    const CurrentRecord& record,
+    size_t idx,
+    const ContentBlock& cb) {
+  bool readNext = true;
+  size_t blockSize = cb.getBlockSize();
+  if (blockSize == ContentBlock::kSizeUnknown) {
+    // just read everything left, without trying to analyse content
+    blockSize = record.reader->getUnreadBytes();
+    readNext = false;
+  }
+  unique_ptr<ContentChunk> bufferSourceChunk = make_unique<ContentChunk>(blockSize);
+  int status = record.reader->read(bufferSourceChunk->getBuffer());
+  if (status != 0) {
+    XR_LOGW("Failed to read {} block: {}", cb.asString(), errorCodeToMessage(status));
+  }
+  chunks_.emplace_back(move(bufferSourceChunk));
+  return readNext;
+}
+
+void RecordFilterCopier::pushDataLayout(DataLayout& datalayout) {
+  datalayout.collectVariableDataAndUpdateIndex();
+  chunks_.emplace_back(make_unique<ContentChunk>(datalayout));
+}
+
+} // namespace vrs::utils

--- a/vrs/utils/FilterCopyHelpers.h
+++ b/vrs/utils/FilterCopyHelpers.h
@@ -1,0 +1,229 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <deque>
+
+#include <vrs/Compressor.h>
+#include <vrs/RecordFormatStreamPlayer.h>
+#include <vrs/Recordable.h>
+
+namespace vrs::utils {
+
+using std::deque;
+using std::unique_ptr;
+
+struct TagOverrides {
+  map<string, string> fileTags;
+  map<StreamId, map<string, string>> streamTags;
+
+  void overrideTags(RecordFileWriter& writer) const;
+};
+
+// Optional parameters for copy (or merge) operations, to override defaults
+struct CopyOptions {
+  CopyOptions(bool showProgress = true) : showProgress{showProgress} {}
+
+  // Compression preset of the output file. Use this method to set the user's explicit choice.
+  void setCompressionPreset(CompressionPreset preset) {
+    userCompressionPreset = preset;
+  }
+  // Compression preset of the output file to use when the user has not made an explicit choice.
+  void setDefaultCompressionPreset(CompressionPreset preset) {
+    defaultCompressionPreset = preset;
+  }
+  CompressionPreset getCompression() const {
+    return userCompressionPreset == CompressionPreset::Undefined ? defaultCompressionPreset
+                                                                 : userCompressionPreset;
+  }
+  // Size of the compression threads pool. Will be limited to HW concurency.
+  unsigned compressionPoolSize = std::numeric_limits<unsigned>::max();
+  // Printout text output to stdout, to monitor progress
+  bool showProgress = true;
+  // Grace timestamp-time window, records may be sent to write in the background thread
+  double graceWindow = 0;
+  // Format output as json, to be able to parse stdout
+  bool jsonOutput = false;
+  // To automatically chunk the output file, specify a max chunk size in MB. 0 means no chunking.
+  size_t maxChunkSizeMB = 0;
+  // For copy/merge operations: set of tags to override in the output file
+  TagOverrides tagOverrides;
+  // For merge operations only: tell if streams with the same RecordableTypeId should be merged.
+  bool mergeStreams = false;
+  // Count the number of records copied. Set during the copy/merge operation.
+  mutable uint32_t outRecordCopiedCount = 0;
+  // Maybe: output URI if the destination's storage system decides where to write the file
+  mutable string outUri;
+
+ private:
+  CompressionPreset userCompressionPreset = CompressionPreset::Undefined;
+  CompressionPreset defaultCompressionPreset = CompressionPreset::ZstdLight;
+};
+
+// Helper to write records, as given by the Copier class below.
+class Writer : public Recordable {
+ public:
+  Writer(RecordableTypeId typeId, const string& flavor) : Recordable(typeId, flavor) {}
+
+  const Record* createStateRecord();
+  const Record* createConfigurationRecord();
+  const Record* createRecord(const CurrentRecord& record, vector<int8_t>& data);
+  const Record* createRecord(const CurrentRecord& record, DataSource& source);
+  const Record*
+  createRecord(double timestamp, Record::Type type, uint32_t formatVersion, DataSource& src);
+};
+
+// Helper to copy a RecordFileReader's given stream's records, to a RecordFileWriter.
+// Does all the hooking up to the read & written files, and copies the stream's tags.
+// Each record read, of any kind, is simply passed through to the written file.
+class Copier : public StreamPlayer {
+ public:
+  Copier(
+      RecordFileReader& fileReader,
+      RecordFileWriter& fileWriter,
+      StreamId id,
+      const CopyOptions& copyOptions);
+
+  bool processRecordHeader(const CurrentRecord& record, DataReference& outDataRef) override;
+  void processRecord(const CurrentRecord& record, uint32_t bytesWrittenCount) override;
+
+  Writer& getWriter() {
+    return writer_;
+  }
+
+ protected:
+  Writer writer_;
+  RecordFileWriter& fileWriter_;
+  const CopyOptions& options_;
+  vector<int8_t> rawRecordData_;
+};
+
+class ContentChunk {
+ public:
+  ContentChunk() = default;
+  ContentChunk(DataLayout& layout);
+  ContentChunk(size_t size) {
+    buffer_.resize(size);
+  }
+  ContentChunk(vector<uint8_t>&& buffer) : buffer_{buffer} {}
+  virtual ~ContentChunk() = default;
+  vector<uint8_t>& getBuffer() {
+    return buffer_;
+  }
+  // maybe do some data processing before we write out the data.
+  virtual size_t filterBuffer() {
+    return buffer_.size();
+  }
+  void fillAndAdvanceBuffer(uint8_t*& buffer) const;
+
+ private:
+  vector<uint8_t> buffer_;
+};
+
+class ContentBlockChunk : public ContentChunk {
+ public:
+  ContentBlockChunk(const ContentBlock& contentBlock, const CurrentRecord& record);
+  ContentBlockChunk(const ContentBlock& contentBlock, vector<uint8_t>&& buffer);
+
+  const ContentBlock& getContentBlock() const {
+    return contentBlock_;
+  }
+
+ protected:
+  const ContentBlock contentBlock_;
+};
+
+class FilteredChunksSource : public DataSource {
+ public:
+  FilteredChunksSource(deque<unique_ptr<ContentChunk>>& chunks)
+      : DataSource(getFilteredChunksSize(chunks)), chunks_{chunks} {}
+  void copyTo(uint8_t* buffer) const override;
+
+ private:
+  static size_t getFilteredChunksSize(const deque<unique_ptr<ContentChunk>>& chunks);
+
+  deque<unique_ptr<ContentChunk>>& chunks_;
+};
+
+// Helper to filter records of a stream while copying them. It's an advanced version of Copier,
+// that provides hooks to decide if a particular record should be copied verbatim, or modified.
+// RecordFilterCopier can handle any record that RecordFormatStreamPlayer can parse.
+class RecordFilterCopier : public RecordFormatStreamPlayer {
+ public:
+  RecordFilterCopier(
+      RecordFileReader& fileReader,
+      RecordFileWriter& fileWriter,
+      StreamId id,
+      const CopyOptions& copyOptions);
+
+  // Tell if this particular record should be copied verbatim, or edited.
+  virtual bool shouldCopyVerbatim(const CurrentRecord& record) = 0;
+
+  // Modify the output record's timestamp, record format version, or record type (rarely needed).
+  virtual void doHeaderEdits(CurrentRecord& record) {}
+
+  // Edit DataLayout blocks, if needed.
+  // Use DataLayout's findDataPieceXXX methods to find the fields you want to edit,
+  // so you can set or stage a different value.
+  virtual void doDataLayoutEdits(const CurrentRecord& record, size_t blockIndex, DataLayout& dl) {}
+
+  // Filter image blocks. If the filter is more than a simple pixel buffer modification,
+  // in particular if a pixel format conversion and/or a resolution change are made,
+  // make sure to make the corresponding changes in the datalayout that describes the image format.
+  virtual void filterImage(
+      const CurrentRecord& record,
+      size_t blockIndex,
+      const ContentBlock& imageBlock,
+      vector<uint8_t>& pixels) {}
+
+  // Filter audio blocks. If the filter is more than a simple audio samples buffer modification,
+  // make sure to make the corresponding changes in the datalayout that describes the audio format.
+  virtual void filterAudio(
+      const CurrentRecord& record,
+      size_t blockIndex,
+      const ContentBlock& audioBlock,
+      vector<uint8_t>& audioSamples) {}
+
+  // Call if while processing a record, you decide that this record should not be copied.
+  void skipRecord() {
+    skipRecord_ = true;
+  }
+
+  // Called after all the content chunks have been received. By default, write-out new record.
+  virtual void finishRecordProcessing(const CurrentRecord& record);
+
+ protected:
+  bool processRecordHeader(const CurrentRecord& record, DataReference& outDataReference) override;
+  void processRecord(const CurrentRecord& record, uint32_t readSize) override;
+  bool onDataLayoutRead(const CurrentRecord& record, size_t blockIndex, DataLayout&) override;
+  bool onImageRead(const CurrentRecord& record, size_t blockIndex, const ContentBlock& cb) override;
+  bool onAudioRead(const CurrentRecord& record, size_t blockIndex, const ContentBlock& cd) override;
+  bool onUnsupportedBlock(const CurrentRecord& record, size_t idx, const ContentBlock& cb) override;
+  /// after processing a datalayout, make sure it's written out in the record
+  void pushDataLayout(DataLayout& dataLayout);
+  Writer& getWriter() {
+    return writer_;
+  }
+
+  Writer writer_;
+  RecordFileWriter& fileWriter_;
+  const CopyOptions& options_;
+  bool copyVerbatim_;
+  bool skipRecord_;
+  deque<unique_ptr<ContentChunk>> chunks_;
+  vector<int8_t> verbatimRecordData_;
+};
+
+} // namespace vrs::utils

--- a/vrs/utils/FilteredFileReader.cpp
+++ b/vrs/utils/FilteredFileReader.cpp
@@ -1,0 +1,672 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "FilteredFileReader.h"
+
+#include <cmath>
+
+#include <iomanip>
+#include <sstream>
+
+#include <vrs/helpers/Strings.h>
+#include <vrs/os/Utils.h>
+
+namespace vrs::utils {
+
+using namespace std;
+using namespace vrs;
+
+#define LOG_ERROR(x)                                                                              \
+  do {                                                                                            \
+    int error = x;                                                                                \
+    if (error) {                                                                                  \
+      cerr << "Error while doing '" << #x << "': " << error << ", " << errorCodeToMessage(error); \
+    }                                                                                             \
+  } while (false)
+
+namespace {
+
+// string ids: a text description of one or more streams.
+// const set<StreamId>& fileStreams: set of known streams
+// set<StreamId>& outStreamIds: set of stream ids extracted
+// returns true if no parsing error occurred.
+// Supported forms for ids:
+//   N-M  where N is a recordable type id as a number, and M an instance id (also a number)
+//   N-   where N is a recordable type id as a number.
+//        Returns all the streams in fileStreams with that recordable type id
+//   N    Same as N-
+// Actual examples: 1004-1 or 1005- or 1005
+bool stringToIds(const string& ids, const set<StreamId>& fileStreams, set<StreamId>& outStreamIds) {
+  stringstream ss(ids);
+  int typeIdNum;
+  bool error = false;
+  if (ss >> typeIdNum) {
+    RecordableTypeId typeId = static_cast<RecordableTypeId>(typeIdNum);
+    bool singleRecordable = false;
+    if (ss.peek() == '-') {
+      ss.ignore();
+      uint16_t instanceId;
+      if (ss >> instanceId) {
+        outStreamIds.insert({typeId, instanceId});
+        singleRecordable = true;
+      } else {
+        string rest;
+        if (ss >> rest && !rest.empty()) {
+          error = true;
+        }
+      }
+    } else if (!ss.eof()) {
+      error = true;
+    }
+    if (!error && !singleRecordable) {
+      for (const auto& id : fileStreams) {
+        if (id.getTypeId() == typeId) {
+          outStreamIds.insert(id);
+        }
+      }
+    }
+  }
+  if (error) {
+    cerr << "Can't parse '" << ids << "' as one or more stream id." << endl;
+  }
+  return !error;
+}
+
+Record::Type stringToType(const string& type) {
+  if (helpers::startsWith("configuration", type)) {
+    return Record::Type::CONFIGURATION;
+  }
+  if (helpers::startsWith("state", type)) {
+    return Record::Type::STATE;
+  }
+  if (helpers::startsWith("data", type)) {
+    return Record::Type::DATA;
+  }
+  cerr << "Can't parse '" << type << "' as a record type." << endl;
+  return Record::Type::UNDEFINED;
+}
+
+inline bool isSigned(const string& str) {
+  return !str.empty() && (str.front() == '+' || str.front() == '-');
+}
+
+bool isValidNumericName(const string& numericName) {
+  if (StreamId::fromNumericName(numericName).isValid()) {
+    return true;
+  }
+  try {
+    unsigned long id = stoul(numericName);
+    return id > 0 && id < 0xffff;
+  } catch (logic_error&) {
+    return false;
+  }
+}
+
+} // namespace
+
+bool RecordFilterParams::includeStream(const string& numericName) {
+  if (!isValidNumericName(numericName)) {
+    return false;
+  }
+  streamFilters.emplace_back("+");
+  streamFilters.emplace_back(numericName);
+  return true;
+}
+
+bool RecordFilterParams::excludeStream(const string& numericName) {
+  if (!isValidNumericName(numericName)) {
+    return false;
+  }
+  streamFilters.emplace_back("-");
+  streamFilters.emplace_back(numericName);
+  return true;
+}
+
+bool RecordFilterParams::includeType(const string& type) {
+  if (stringToType(type) == Record::Type::UNDEFINED) {
+    return false;
+  }
+  typeFilters.emplace_back("+");
+  typeFilters.emplace_back(type);
+  return true;
+}
+
+bool RecordFilterParams::excludeType(const string& type) {
+  if (stringToType(type) == Record::Type::UNDEFINED) {
+    return false;
+  }
+  typeFilters.emplace_back("-");
+  typeFilters.emplace_back(type);
+  return true;
+}
+
+bool FilteredFileReader::fileExists() const {
+  if (!path.empty() && path[0] == '{') {
+    return true; // Assume json paths exist, to avoid breaking sanity checks
+  }
+  return os::pathExists(path);
+}
+
+string FilteredFileReader::getPathOrUri() const {
+  return path;
+}
+
+string FilteredFileReader::getFileName() {
+  if (path.empty()) {
+    return {};
+  }
+  if (path.front() != '{') {
+    return os::getFilename(path);
+  }
+  // if json filepath is used, we want to use either filename or first chunk.
+  FileSpec spec;
+  if (spec.fromJson(path)) {
+    if (spec.fileName.empty() && !spec.chunks.empty()) {
+      spec.fileName = os::getFilename(spec.chunks[0]);
+    }
+  }
+  return spec.fileName;
+}
+
+int64_t FilteredFileReader::getFileSize() const {
+  return os::getFileSize(path);
+}
+
+int FilteredFileReader::openFile(const RecordFilterParams& filters) {
+  int status = path.empty() ? ErrorCode::INVALID_REQUEST : reader.openFile(path);
+  if (status != 0) {
+    return status;
+  }
+  applyFilters(filters);
+  return status;
+}
+
+int FilteredFileReader::openFile(unique_ptr<FileHandler>& file) const {
+  file = make_unique<DiskFile>();
+  int status = file->open(path);
+  if (status != 0) {
+    cerr << "Can't open '" << getPathOrUri() << "': " << errorCodeToMessage(status) << endl;
+  }
+  return status;
+}
+
+string FilteredFileReader::getCopyPath() {
+  // if uploading, but no temp file path has been provided, automatically generate one
+  string fileName = getFileName();
+  return os::getTempFolder() + (fileName.empty() ? "file.tmp" : fileName);
+}
+
+bool FilteredFileReader::afterConstraint(const string& after) {
+  return filter.afterConstraint(after);
+}
+
+bool FilteredFileReader::beforeConstraint(const string& before) {
+  return filter.beforeConstraint(before);
+}
+
+void FilteredFileReader::setMinTime(double minimumTime, bool relativeToBegin) {
+  return filter.setMinTime(minimumTime, relativeToBegin);
+}
+
+void FilteredFileReader::setMaxTime(double maximumTime, bool relativeToEnd) {
+  return filter.setMaxTime(maximumTime, relativeToEnd);
+}
+
+void FilteredFileReader::getTimeRange(double& outStartTimestamp, double& outEndTimestamp) {
+  outStartTimestamp = numeric_limits<double>::max();
+  outEndTimestamp = numeric_limits<double>::lowest();
+  expandTimeRange(outStartTimestamp, outEndTimestamp);
+}
+
+void FilteredFileReader::expandTimeRange(double& inOutStartTimestamp, double& inOutEndTimestamp) {
+  const auto& index = reader.getIndex();
+  if (!index.empty()) {
+    double firstTimestamp = inOutStartTimestamp;
+    double lastTimestamp = inOutEndTimestamp;
+    for (const auto& r : index) {
+      if (filter.streams.find(r.streamId) != filter.streams.end() &&
+          r.recordType == Record::Type::DATA) {
+        firstTimestamp = r.timestamp;
+        break;
+      }
+    }
+    for (auto iter = index.rbegin(); iter != index.rend(); ++iter) {
+      if (filter.streams.find(iter->streamId) != filter.streams.end() &&
+          iter->recordType == Record::Type::DATA) {
+        lastTimestamp = iter->timestamp;
+        break;
+      }
+    }
+    if (firstTimestamp < inOutStartTimestamp) {
+      inOutStartTimestamp = firstTimestamp;
+    }
+    if (lastTimestamp > inOutEndTimestamp) {
+      inOutEndTimestamp = lastTimestamp;
+    }
+  }
+}
+
+void FilteredFileReader::constrainTimeRange(double& inOutStartTimestamp, double& inOutEndTimestamp)
+    const {
+  if (inOutStartTimestamp < filter.minTime) {
+    inOutStartTimestamp = filter.minTime;
+  }
+  if (inOutEndTimestamp > filter.maxTime) {
+    inOutEndTimestamp = filter.maxTime;
+  }
+}
+
+void FilteredFileReader::getConstrainedTimeRange(
+    double& outStartTimestamp,
+    double& outEndTimestamp) {
+  getTimeRange(outStartTimestamp, outEndTimestamp);
+  filter.resolveTimeConstraints(outStartTimestamp, outEndTimestamp);
+  constrainTimeRange(outStartTimestamp, outEndTimestamp);
+}
+
+void FilteredFileReader::applyFilters(const RecordFilterParams& filters) {
+  applyRecordableFilters(filters.streamFilters);
+  applyTypeFilters(filters.typeFilters);
+  if (filters.decimationParams) {
+    decimator_ = make_unique<Decimator>(*this, *filters.decimationParams);
+  }
+}
+
+void FilteredFileReader::applyRecordableFilters(const vector<string>& filters) {
+  const auto& fileStreams = reader.getStreams();
+  unique_ptr<set<StreamId>> newSet;
+  for (auto iter = filters.begin(); iter != filters.end(); ++iter) {
+    if (*iter == "+") {
+      set<StreamId> argIds;
+      stringToIds(*(++iter), fileStreams, argIds);
+      if (!newSet) {
+        // first command is add? start from empty set
+        newSet = make_unique<set<StreamId>>(move(argIds));
+      } else {
+        for (auto id : argIds) {
+          newSet->insert(id);
+        }
+      }
+    } else if (*iter == "-") {
+      set<StreamId> argIds;
+      stringToIds(*(++iter), fileStreams, argIds);
+      if (!newSet) {
+        // first command is remove? start with set of all known streams
+        newSet = make_unique<set<StreamId>>(fileStreams);
+      }
+      for (auto id : argIds) {
+        newSet->erase(id);
+      }
+    }
+  }
+  if (newSet) {
+    // Only include streams present in the file
+    this->filter.streams.clear();
+    for (auto id : *newSet) {
+      if (fileStreams.find(id) != fileStreams.end()) {
+        this->filter.streams.insert(id);
+      }
+    }
+  } else {
+    this->filter.streams = fileStreams;
+  }
+}
+
+void FilteredFileReader::applyTypeFilters(const vector<string>& filters) {
+  set<Record::Type> types = {Record::Type::CONFIGURATION, Record::Type::DATA, Record::Type::STATE};
+  set<Record::Type>* newSet = nullptr;
+  for (auto iter = filters.begin(); iter != filters.end(); ++iter) {
+    const bool isPlus = *iter == "+";
+    Record::Type readType = stringToType(*(++iter));
+    if (readType != Record::Type::UNDEFINED) {
+      if (isPlus) {
+        if (newSet == nullptr) {
+          // first command is add? start from empty set
+          newSet = new set<Record::Type>();
+        }
+        newSet->insert(readType);
+      } else { // if it's not a '+', then it was a '-'
+        if (newSet == nullptr) {
+          // first command is remove? start with set of all known streams
+          newSet = new set<Record::Type>(types);
+        }
+        newSet->erase(readType);
+      }
+    }
+  }
+  if (newSet != nullptr) {
+    this->filter.types = move(*newSet);
+  } else {
+    this->filter.types = move(types);
+  }
+}
+
+bool RecordFilter::afterConstraint(const string& after) {
+  try {
+    setMinTime(stod(after), isSigned(after));
+    return true;
+  } catch (logic_error&) {
+    return false;
+  }
+}
+
+void RecordFilter::setMinTime(double minimumTime, bool relativeToBegin) {
+  minTime = minimumTime;
+  relativeMinTime = relativeToBegin;
+}
+
+bool RecordFilter::beforeConstraint(const string& before) {
+  try {
+    setMaxTime(stod(before), isSigned(before));
+    return true;
+  } catch (logic_error&) {
+    return false;
+  }
+}
+
+void RecordFilter::setMaxTime(double maximumTime, bool relativeToEnd) {
+  maxTime = maximumTime;
+  relativeMaxTime = relativeToEnd;
+}
+
+bool RecordFilter::resolveTimeConstraints(double startTimestamp, double endTimestamp) {
+  if (relativeMinTime || relativeMaxTime || aroundTime) {
+    if (relativeMinTime) {
+      minTime += (minTime < 0) ? endTimestamp : startTimestamp;
+    }
+    if (aroundTime) {
+      // maxTime is actually a duration centered around minTime: interpret both
+      double baseTime = minTime;
+      double diameter = abs(maxTime) / 2;
+      minTime = baseTime - diameter;
+      maxTime = baseTime + diameter;
+    } else if (relativeMaxTime) {
+      maxTime += (maxTime < 0) ? endTimestamp : startTimestamp;
+    }
+    relativeMinTime = false;
+    relativeMaxTime = false;
+    aroundTime = false;
+  }
+  return minTime <= maxTime;
+}
+
+bool FilteredFileReader::resolveTimeConstraints() {
+  const auto& index = reader.getIndex();
+  return index.empty()
+      ? true
+      : filter.resolveTimeConstraints(index.front().timestamp, index.back().timestamp);
+}
+
+string RecordFilter::getTimeConstraintDescription() const {
+  bool minLimited = minTime > numeric_limits<double>::lowest();
+  bool maxLimited = maxTime < numeric_limits<double>::max();
+  stringstream oss;
+  oss << fixed << setprecision(3);
+  if (minLimited && maxLimited) {
+    oss << " between " << minTime << " and " << maxTime << " sec";
+  } else if (minLimited) {
+    oss << " after " << minTime << " sec";
+  } else if (maxLimited) {
+    oss << " before " << maxTime << " sec";
+  }
+  return oss.str();
+}
+
+Decimator::Decimator(FilteredFileReader& filteredReader, DecimationParams& params)
+    : filteredReader_{filteredReader},
+      bucketInterval_{params.bucketInterval},
+      bucketMaxTimestampDelta_{params.bucketMaxTimestampDelta},
+      graceWindow_{bucketInterval_ * 1.2} {
+  const auto& fileStreams = filteredReader_.reader.getStreams();
+  for (const auto& interval : params.decimationIntervals) {
+    set<StreamId> argIds;
+    stringToIds(interval.first, fileStreams, argIds);
+    for (auto id : argIds) {
+      decimationIntervals_[id] = interval.second;
+    }
+  }
+}
+
+void Decimator::reset() {
+  decimateCursors_.clear();
+  bucketCurrentTimestamp_ = numeric_limits<double>::quiet_NaN();
+  bucketCandidates_.clear();
+}
+
+double Decimator::getGraceWindow() const {
+  return graceWindow_;
+}
+
+bool Decimator::decimate(
+    RecordReaderFunc& recordReaderFunc,
+    ThrottledWriter* throttledWriter,
+    const IndexRecord::RecordInfo& record,
+    bool& inOutKeepGoing) {
+  // only decimate data records
+  if (record.recordType != Record::Type::DATA) {
+    return false;
+  }
+  // Interval decimation
+  if (!decimationIntervals_.empty()) {
+    auto decimateInterval = decimationIntervals_.find(record.streamId);
+    if (decimateInterval != decimationIntervals_.end()) {
+      auto decimateCursor = decimateCursors_.find(record.streamId);
+      if (decimateCursor != decimateCursors_.end() &&
+          record.timestamp < decimateCursor->second + decimateInterval->second) {
+        return true; // Decimate this record
+      }
+      // Keep this record & remember its timestamp
+      decimateCursors_[record.streamId] = record.timestamp;
+    }
+    return false;
+  }
+  // Bucket decimation
+  if (bucketInterval_ > 0) {
+    if (isnan(bucketCurrentTimestamp_)) {
+      bucketCurrentTimestamp_ = record.timestamp;
+    }
+    // are we past the limit for the current bucket?
+    if (record.timestamp - bucketCurrentTimestamp_ > bucketMaxTimestampDelta_) {
+      // no chance of finding better candidates, we need to "submit" this bucket
+      inOutKeepGoing = submitBucket(recordReaderFunc, throttledWriter);
+      bucketCurrentTimestamp_ += bucketInterval_;
+    }
+    // does this frame qualify for the bucket?
+    else if (fabs(record.timestamp - bucketCurrentTimestamp_) <= bucketMaxTimestampDelta_) {
+      // can we find a closer candidate for the bucket for this stream id?
+      const auto it = bucketCandidates_.find(record.streamId);
+      if (it == bucketCandidates_.end() ||
+          fabs(it->second->timestamp - bucketCurrentTimestamp_) <
+              fabs(record.timestamp - bucketCurrentTimestamp_)) {
+        bucketCandidates_[record.streamId] = &record;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+void Decimator::flush(RecordReaderFunc& recordReaderFunc, ThrottledWriter* throttledWriter) {
+  if (bucketInterval_ > 0) {
+    submitBucket(recordReaderFunc, throttledWriter);
+  }
+}
+
+bool Decimator::submitBucket(RecordReaderFunc& recordReaderFunc, ThrottledWriter* throttledWriter) {
+  bool keepGoing = true;
+  double maxTimestamp = 0.0;
+  for (const auto& bucketRecord : bucketCandidates_) {
+    keepGoing = keepGoing && recordReaderFunc(filteredReader_.reader, *bucketRecord.second);
+    maxTimestamp = max(maxTimestamp, bucketRecord.second->timestamp);
+  }
+  bucketCandidates_.clear();
+  if (throttledWriter != nullptr) {
+    throttledWriter->onRecordDecoded(maxTimestamp, graceWindow_);
+  }
+  return keepGoing;
+}
+
+string FilteredFileReader::getTimeConstraintDescription() {
+  resolveTimeConstraints();
+  return filter.getTimeConstraintDescription();
+}
+
+inline bool configOrStateRecord(const IndexRecord::RecordInfo& record) {
+  return record.recordType == Record::Type::CONFIGURATION ||
+      record.recordType == Record::Type::STATE;
+}
+
+void FilteredFileReader::preRollConfigAndState() {
+  preRollConfigAndState(
+      [](RecordFileReader& recordFileReader, const IndexRecord::RecordInfo& record) {
+        LOG_ERROR(recordFileReader.readRecord(record));
+        return true;
+      });
+}
+
+void FilteredFileReader::preRollConfigAndState(RecordReaderFunc recordReaderFunc) {
+  if (!resolveTimeConstraints()) {
+    return;
+  }
+  if (filter.minTime <= numeric_limits<double>::lowest()) {
+    return; // not needed: we'll read records from the start
+  }
+  vector<size_t> indexes;
+  const auto& records = reader.getIndex();
+  // to compare: only the timestamps matters!
+  IndexRecord::RecordInfo firstTime(filter.minTime, 0, StreamId(), Record::Type());
+  auto lowerBound = lower_bound(records.begin(), records.end(), firstTime);
+  if (lowerBound != records.end()) {
+    size_t index = static_cast<size_t>(lowerBound - records.begin()); // guaranteed positive
+    // For each stream & record type, track the records we need to write
+    set<pair<StreamId, Record::Type>> foundRecords;
+    // for each stream, 1 config + 1 state record
+    size_t requiredCount = filter.streams.size() * 2;
+    indexes.reserve(requiredCount);
+    // search records *before* the lower bound index we found
+    while (requiredCount > 0 && index-- > 0) {
+      const IndexRecord::RecordInfo& record = records[index];
+      if (configOrStateRecord(record) &&
+          filter.types.find(record.recordType) != filter.types.end() &&
+          filter.streams.find(record.streamId) != filter.streams.end() &&
+          foundRecords.find({record.streamId, record.recordType}) == foundRecords.end()) {
+        foundRecords.insert({record.streamId, record.recordType});
+        indexes.push_back(index);
+        requiredCount--;
+      }
+    }
+  }
+  // we found the records in reserse chronological order: read records sequentially now
+  for (size_t k = indexes.size(); k-- > 0; /* size_t is unsigned: loop carefully! */) {
+    recordReaderFunc(reader, records[indexes[k]]);
+  }
+}
+
+unique_ptr<deque<IndexRecord::DiskRecordInfo>> FilteredFileReader::buildIndex() {
+  auto preliminaryIndex = make_unique<deque<IndexRecord::DiskRecordInfo>>();
+  int64_t offset = 0;
+  function<bool(RecordFileReader&, const IndexRecord::RecordInfo&)> f =
+      [&preliminaryIndex, &offset](RecordFileReader&, const IndexRecord::RecordInfo& record) {
+        preliminaryIndex->push_back(
+            {record.timestamp,
+             static_cast<uint32_t>(record.fileOffset - offset),
+             record.streamId,
+             record.recordType});
+        offset = record.fileOffset;
+        return true;
+      };
+  preRollConfigAndState(f);
+  iterate(f);
+  return preliminaryIndex;
+}
+
+uint32_t FilteredFileReader::iterate(ThrottledWriter* throttledWriter) {
+  if (!resolveTimeConstraints()) {
+    cerr << "Time Range invalid: " << getTimeConstraintDescription() << endl;
+    return 0;
+  }
+  uint32_t readCounter = 0;
+  iterate(
+      [&readCounter](RecordFileReader& recordFileReader, const IndexRecord::RecordInfo& record) {
+        LOG_ERROR(recordFileReader.readRecord(record));
+        readCounter++;
+        return true;
+      },
+      throttledWriter);
+  for (auto id : filter.streams) {
+    reader.setStreamPlayer(id, nullptr);
+  }
+  return readCounter;
+}
+
+void FilteredFileReader::iterate(RecordReaderFunc recReaderF, ThrottledWriter* throttledWriter) {
+  if (!resolveTimeConstraints()) {
+    return;
+  }
+
+  using RecordFlavor = tuple<StreamId, Record::Type>;
+  set<RecordFlavor> firstRecordsOnlyTracking;
+  bool keepGoing = true;
+
+  double graceWindow = decimator_ ? decimator_->getGraceWindow() : 0;
+  if (decimator_) {
+    decimator_->reset();
+  }
+
+  const auto& records = reader.getIndex();
+  IndexRecord::RecordInfo firstTime(filter.minTime, 0, StreamId(), Record::Type());
+  auto lowerBound = lower_bound(records.begin(), records.end(), firstTime);
+  if (lowerBound != records.end()) {
+    size_t first = static_cast<size_t>(lowerBound - records.begin());
+    for (size_t k = first; keepGoing && k < records.size(); ++k) {
+      const IndexRecord::RecordInfo& record = records[k];
+
+      if (record.timestamp > filter.maxTime) {
+        break; // Records are sorted by timestamp: no need to keep trying
+      }
+      if (filter.streams.find(record.streamId) == filter.streams.end() ||
+          filter.types.find(record.recordType) == filter.types.end()) {
+        continue;
+      }
+
+      if (firstRecordsOnly) {
+        if (firstRecordsOnlyTracking.size() >= filter.streams.size() * 3) {
+          break; // we found 1 config, state and data record per stream, we can stop now
+        }
+        RecordFlavor recordFlavor{record.streamId, record.recordType};
+        if (firstRecordsOnlyTracking.find(recordFlavor) == firstRecordsOnlyTracking.end()) {
+          firstRecordsOnlyTracking.insert(recordFlavor);
+        } else {
+          continue;
+        }
+      }
+
+      if ((decimator_ && decimator_->decimate(recReaderF, throttledWriter, record, keepGoing)) ||
+          (skipRecordFilter && skipRecordFilter(record))) {
+        continue;
+      }
+
+      keepGoing = keepGoing && recReaderF(reader, record);
+      if (throttledWriter != nullptr) {
+        throttledWriter->onRecordDecoded(record.timestamp, graceWindow);
+      }
+    }
+
+    if (decimator_) {
+      decimator_->flush(recReaderF, throttledWriter);
+    }
+  }
+}
+
+} // namespace vrs::utils

--- a/vrs/utils/FilteredFileReader.h
+++ b/vrs/utils/FilteredFileReader.h
@@ -1,0 +1,208 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+#include <limits>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <vrs/Record.h>
+#include <vrs/RecordFileReader.h>
+#include <vrs/RecordFileWriter.h>
+
+#include <vrs/utils/ThrottleHelpers.h>
+
+namespace vrs::utils {
+
+struct FilteredFileReader;
+
+using RecordReaderFunc = function<bool(RecordFileReader&, const IndexRecord::RecordInfo&)>;
+
+struct DecimationParams {
+  // Per stream decimation intervals
+  vector<pair<string, double>> decimationIntervals;
+  // Divide time where we have all records into intervals, 0 to disable bucketing
+  double bucketInterval = 0.0;
+  // Disregard records which timestamp is more than this delta away from the bucket's
+  double bucketMaxTimestampDelta = 1.0 / 30.0;
+};
+
+/// Filters as specified using the command line, as a series of parameters, grouped by type
+struct RecordFilterParams {
+  vector<string> streamFilters;
+  vector<string> typeFilters;
+  unique_ptr<DecimationParams> decimationParams;
+
+  // Add contraints, typically from command line options
+  bool includeStream(const string& numericName);
+  bool excludeStream(const string& numericName);
+  bool includeType(const string& type);
+  bool excludeType(const string& type);
+};
+
+/// Class to filter out some parts of a VRS file when reading it.
+/// This class merely holds some constraints.
+struct RecordFilter {
+  set<StreamId> streams;
+  set<Record::Type> types;
+  bool relativeMinTime = false;
+  bool relativeMaxTime = false;
+  bool aroundTime = false;
+  double minTime = std::numeric_limits<double>::lowest();
+  double maxTime = std::numeric_limits<double>::max();
+
+  // Add time constraints, typically from command line options,
+  // with interpretation of an eventual sign character as relative to the file's begin/end
+  bool afterConstraint(const string& after);
+  bool beforeConstraint(const string& before);
+  void setMinTime(double minimumTime, bool relativeToBegin);
+  void setMaxTime(double maximumTime, bool relativeToEnd);
+
+  // Resolve relative time constraints based on the given start & end timestamps
+  bool resolveTimeConstraints(double startTimestamp, double endTimestamp);
+  string getTimeConstraintDescription() const;
+};
+
+/// Class handling stream interval & bucket decimation
+class Decimator {
+ public:
+  Decimator(FilteredFileReader& filteredReader, DecimationParams& params);
+
+  // chance to reset internal state before each iteration
+  void reset();
+  // tell if a record should be read decimated (return true)
+  bool decimate(
+      RecordReaderFunc& recordReaderFunc,
+      ThrottledWriter* throttledWriter,
+      const IndexRecord::RecordInfo& record,
+      bool& inOutKeepGoing);
+  // chance to process final records before the end of an iteration
+  void flush(RecordReaderFunc& recordReaderFunc, ThrottledWriter* throttledWriter);
+
+  double getGraceWindow() const;
+
+ private:
+  bool submitBucket(RecordReaderFunc& recordReaderFunc, ThrottledWriter* throttledWriter);
+
+  FilteredFileReader& filteredReader_;
+  // Timestamp intervals used to skip data records (does not apply to config and state records)
+  map<StreamId, double> decimationIntervals_;
+  // Divide time where we have all records into intervals, 0 to disable bucketing
+  const double bucketInterval_;
+  // Disregard records which timestamp is more than this delta away from the bucket's
+  const double bucketMaxTimestampDelta_;
+  // Grace time window to avoid unsorted records because of pending buckets
+  const double graceWindow_;
+
+  // iteration specific variables
+  map<StreamId, double> decimateCursors_;
+  // Timestamp of the current bucket we are creating
+  double bucketCurrentTimestamp_;
+  map<StreamId, const IndexRecord::RecordInfo*> bucketCandidates_;
+};
+
+/// Encapsulation of a VRS file to read, along with filters to only reads some records/streams.
+struct FilteredFileReader {
+  string path;
+  RecordFileReader reader;
+  RecordFilter filter;
+  // custom filter: return true to skip record
+  function<bool(const IndexRecord::RecordInfo&)> skipRecordFilter;
+  // optional decimator
+  unique_ptr<Decimator> decimator_;
+  bool firstRecordsOnly = false;
+
+  FilteredFileReader() = default;
+  FilteredFileReader(const string& filePath, const unique_ptr<FileHandler>& vrsFileProvider = {}) {
+    setSource(filePath, vrsFileProvider);
+  }
+  virtual ~FilteredFileReader() = default;
+
+  void setSource(const string& filePath, const unique_ptr<FileHandler>& vrsFileProvider = {}) {
+    path = filePath;
+    if (vrsFileProvider) {
+      reader.setFileHandler(vrsFileProvider->makeNew());
+    }
+  }
+
+  virtual bool fileExists() const;
+  virtual string getPathOrUri() const;
+  virtual string getFileName();
+  virtual int64_t getFileSize() const;
+
+  virtual int openFile(const RecordFilterParams& filters = {});
+
+  // Open the file, local or not, as a standard file
+  virtual int openFile(unique_ptr<FileHandler>& file) const;
+
+  string getCopyPath();
+
+  // Add constraints, typically from command line options
+  bool afterConstraint(const string& after);
+  bool beforeConstraint(const string& before);
+  bool includeStream(const string& numericName);
+  bool excludeStream(const string& numericName);
+
+  // Set time constraints, maybe relative to first/last data records
+  void setMinTime(double minimumTime, bool relativeToBegin);
+  void setMaxTime(double maximumTime, bool relativeToEnd);
+
+  // Apply time constrains & get resulting range in one call.
+  void getConstrainedTimeRange(double& outStartTimestamp, double& outEndTimestamp);
+
+  // Get the time range including the data records of the considered streams only.
+  // The file must be opened already.
+  // The resulting values are used to convert file-relative timestamps into absolute timestamps.
+  void getTimeRange(double& outStartTimestamp, double& outEndTimestamp);
+  // Expand an existing timerange to include the data records of the considered streams only.
+  void expandTimeRange(double& inOutStartTimestamp, double& inOutEndTimestamp);
+  // Constrain the given time range to the current filter's time constraints
+  void constrainTimeRange(double& inOutStartTimestamp, double& inOutEndTimestamp) const;
+
+  // Apply filters, which can only be done after the file was opened already
+  void applyFilters(const RecordFilterParams& filters);
+  void applyRecordableFilters(const vector<string>& filter);
+  void applyTypeFilters(const vector<string>& filter);
+
+  // Time constraints can be relative to the begin/end timestamps.
+  // If necessary, convert relative time constraints into relative constraints on the file.
+  bool resolveTimeConstraints();
+  string getTimeConstraintDescription();
+
+  // Make an index of the filtered records. Useful to pre-allocate the index during copy operations.
+  unique_ptr<deque<IndexRecord::DiskRecordInfo>> buildIndex();
+
+  // Make sure the lastest config & state records are read before reading.
+  // Needed when we don't read from the start
+  // This version reads the records
+  void preRollConfigAndState();
+  // Make sure the lastest config & state records are read before reading.
+  // Needed when we don't read from the start
+  // This version hands the records to the function provided
+  void preRollConfigAndState(RecordReaderFunc recordReaderFunc);
+
+  // Read all the records of the reader than meet the specs
+  // Use a ThrottledWriter object to get a callback after each record is decoded
+  uint32_t iterate(ThrottledWriter* throttledWriter = nullptr);
+
+  // Iterate and call the provided function for each record
+  // Use a ThrottledWriter object to get a callback after each record is decoded
+  void iterate(RecordReaderFunc recordReaderFunc, ThrottledWriter* throttledWriter = nullptr);
+};
+
+}; // namespace vrs::utils

--- a/vrs/utils/ThrottleHelpers.cpp
+++ b/vrs/utils/ThrottleHelpers.cpp
@@ -1,0 +1,156 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ThrottleHelpers.h"
+
+#include <iomanip>
+
+#include <vrs/helpers/Strings.h>
+#include <vrs/os/Time.h>
+
+namespace {
+
+#if IS_LINUX_PLATFORM() || IS_MAC_PLATFORM() || IS_WINDOWS_PLATFORM()
+// No need to be stingy on memory usage on desktop platforms
+const size_t kMaxQueueByteSize = 2 * 1024 * 1024 * 1024ULL; // 2 GB
+#else
+// Mobile environments are constrained, and might kill a greedy app...
+const size_t kMaxQueueByteSize = 600 * 1024 * 1024; // 600 MB
+#endif
+const size_t kReadAgainQueueByteSize = kMaxQueueByteSize * 9 / 10; // 90%
+const size_t kLowQueueByteSize = 40 * 1024 * 1024ULL;
+
+const double kRefreshDelaySec = 1. / 3; // limit how frequently we show updates
+
+} // namespace
+
+namespace vrs::utils {
+
+using namespace std;
+using namespace vrs;
+
+const size_t kDownloadChunkSize = 1024 * 1024 * 4;
+
+#if IS_WINDOWS_PLATFORM()
+// "\r" works, but escape sequences don't by default: overwrite with
+// white spaces... :-(
+const char* const kResetCurrentLine = "\r                                            \r";
+#else
+const char* const kResetCurrentLine = "\r\33[2K\r";
+#endif
+
+ThrottledWriter::ThrottledWriter(const CopyOptions& options) : copyOptions_{options} {
+  writer_.trackBackgroundThreadQueueByteSize();
+  initWriter();
+  nextUpdateTime_ = 0;
+}
+
+void ThrottledWriter::initWriter() {
+  writer_.setCompressionThreadPoolSize(
+      std::min<size_t>(copyOptions_.compressionPoolSize, thread::hardware_concurrency()));
+  writer_.setMaxChunkSizeMB(copyOptions_.maxChunkSizeMB);
+}
+
+vrs::RecordFileWriter& ThrottledWriter::getWriter() {
+  return writer_;
+}
+
+void ThrottledWriter::initTimeRange(double minTimestamp, double maxTimestamp) {
+  minTimestamp_ = minTimestamp;
+  duration_ = maxTimestamp - minTimestamp;
+}
+
+void ThrottledWriter::onRecordDecoded(double timestamp, double writeGraceWindow) {
+  uint64_t queueByteSize = writer_.getBackgroundThreadQueueByteSize();
+  const uint32_t writeInterval = copyOptions_.outRecordCopiedCount < 100 ? 10 : 100;
+  if (queueByteSize == 0 || copyOptions_.outRecordCopiedCount % writeInterval == 0) {
+    writer_.writeRecordsAsync(timestamp - max<double>(writeGraceWindow, copyOptions_.graceWindow));
+  }
+  // don't go crazy with memory usage, if we read data much faster than we can process it...
+  if (queueByteSize > kMaxQueueByteSize || (waitCondition_ && waitCondition_())) {
+    writer_.writeRecordsAsync(timestamp - max<double>(writeGraceWindow, copyOptions_.graceWindow));
+    // wait that most of the buffers are processed to resume,
+    // limiting collisions between input & output file operations.
+    do {
+      printPercentAndQueueSize(queueByteSize, true);
+      this_thread::sleep_for(chrono::duration<double>(kRefreshDelaySec));
+      queueByteSize = writer_.getBackgroundThreadQueueByteSize();
+    } while (queueByteSize > kReadAgainQueueByteSize || (waitCondition_ && waitCondition_()));
+    if (showProgress()) {
+      cout << kResetCurrentLine;
+      nextUpdateTime_ = 0;
+    }
+  }
+  if (showProgress()) {
+    double now = os::getTimestampSec();
+    if (now >= nextUpdateTime_) {
+      double progress = duration_ > 0.0001 ? (timestamp - minTimestamp_) / duration_ : 1.;
+      // timestamp ranges only include data records, but config & state records might be beyond
+      percent_ = std::max<int32_t>(static_cast<int32_t>(progress * 100), 0);
+      percent_ = std::min<int32_t>(percent_, 100);
+      printPercentAndQueueSize(writer_.getBackgroundThreadQueueByteSize(), false);
+      nextUpdateTime_ = now + kRefreshDelaySec;
+    }
+  }
+}
+
+void ThrottledWriter::printPercentAndQueueSize(uint64_t queueByteSize, bool waiting) {
+  if (showProgress()) {
+    if (writer_.isWriting()) {
+      cout << kResetCurrentLine << (waiting ? "Waiting " : "Reading ") << setw(2) << percent_
+           << "%, processing " << setw(7) << helpers::humanReadableFileSize(queueByteSize);
+    } else {
+      cout << kResetCurrentLine << "Reading " << setw(2) << percent_ << "%";
+    }
+    cout.flush();
+  }
+}
+
+int ThrottledWriter::closeFile() {
+  if (showProgress()) {
+    writer_.closeFileAsync(); // non-blocking
+    waitForBackgroundThreadQueueSize(kLowQueueByteSize / 3);
+  }
+  int copyResult = writer_.waitForFileClosed(); // blocking call
+  if (showProgress()) {
+    cout << kResetCurrentLine;
+  }
+  return copyResult;
+}
+
+void ThrottledWriter::waitForBackgroundThreadQueueSize(size_t maxSize) {
+  if (showProgress()) {
+    cout << kResetCurrentLine;
+  }
+  // To avoid stalls, don't wait quite until we have nothing left to process,
+  uint64_t queueByteSize;
+  while ((queueByteSize = writer_.getBackgroundThreadQueueByteSize()) > maxSize) {
+    if (showProgress()) {
+      cout << kResetCurrentLine << "Processing " << setw(7)
+           << helpers::humanReadableFileSize(queueByteSize);
+      cout.flush();
+    }
+    // Check more frequently when we're getting close. This is Science.
+    const double sleepDuration = queueByteSize > 3 * kLowQueueByteSize ? kRefreshDelaySec
+        : queueByteSize > kLowQueueByteSize                            ? kRefreshDelaySec / 2
+                                                                       : kRefreshDelaySec / 5;
+    this_thread::sleep_for(chrono::duration<double>(sleepDuration));
+  }
+  if (showProgress()) {
+    cout << kResetCurrentLine << "Finishing...";
+    cout.flush();
+  }
+}
+
+} // namespace vrs::utils

--- a/vrs/utils/ThrottleHelpers.h
+++ b/vrs/utils/ThrottleHelpers.h
@@ -1,0 +1,77 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <vrs/RecordFileWriter.h>
+#include <vrs/utils/FilterCopyHelpers.h>
+
+namespace vrs::utils {
+
+extern const size_t kDownloadChunkSize;
+extern const char* const kResetCurrentLine;
+
+/// Class to control memory usage while writing out to a VRS file
+/// using a RecordFileWriter object.
+class ThrottledWriter {
+ public:
+  ThrottledWriter(const CopyOptions& options);
+
+  /// Init writer with latest copy options values (if they were changed since constructor)
+  void initWriter();
+
+  /// Get a reference to the RecordFileWriter object which progress is being monitored.
+  /// @return The RecordFileWriter used to write the output file.
+  RecordFileWriter& getWriter();
+
+  /// Set the range of timestamps expected, to track progress on the time range.
+  /// @param minTimestamp: earliest timestamp of the operation
+  /// @param maxTimestamp: latest timestamp of the operation
+  void initTimeRange(double minTimestamp, double maxTimestamp);
+
+  /// Called when a record is read, which can allow you to slow down decoding by adding a mere sleep
+  /// in the callback itself. This is the main use case of this callback, as data is queued for
+  /// processing & writing to Disk in a different thread, and we could run out of memory if we don't
+  /// allow the background thread to run further, while we slow down the decoding thread.
+  /// Can also be used to build a UI (GUI or terminal) to monitor progress when copying large files.
+  /// @param timestamp: Timestamp of the record decoded.
+  /// @param writeGraceWindow: Grace window in which records are allowed to be out-of-order.
+  void onRecordDecoded(double timestamp, double writeGraceWindow = 0.0);
+
+  /// Called when we're ready to close the file. On exit, it is expected that the writer is closed.
+  int closeFile();
+
+  void waitForBackgroundThreadQueueSize(size_t maxSize);
+
+  void printPercentAndQueueSize(uint64_t queueByteSize, bool waiting);
+
+  void addWaitCondition(function<bool()> waitCondition) {
+    waitCondition_ = waitCondition;
+  }
+
+  bool showProgress() const {
+    return copyOptions_.showProgress;
+  }
+
+ private:
+  RecordFileWriter writer_;
+  function<bool()> waitCondition_;
+  const CopyOptions& copyOptions_;
+  double nextUpdateTime_ = 0;
+  int32_t percent_ = 0;
+  double minTimestamp_ = 0;
+  double duration_ = 0;
+};
+
+} // namespace vrs::utils


### PR DESCRIPTION
Summary:
FilteredFileReader is a helper that enables reading select parts of a VRS file. It is mostly useful for copy operations that may filter out some records based on timestamp or type, or streams. It can be seen as a specialized iterator that can selectively read a subset of records of a file, so that they can be "processed", whatever that might mean. A simple case might be to copy all the records, as they are, but in a new cleaned-up container, or only copy the first n-seconds of a file, or only some streams, etc.
The copy functionality itself will come in further diffs.

Reviewed By: kiminoue7

Differential Revision: D34290532

