### PR TITLE
Minor OSS CMakeLists.txt structure clean-ups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,17 +14,13 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-set(VRS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
-
-# In Meta's repo, OOS-only bits are in an "oss/" sub-folder
-# OSS_DIR is a relative path to bridge the repo differences
-# so this CMakeLists.txt file works with both layouts.
-if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/oss")
-  set(OSS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/oss")
-else()
-  set(OSS_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+# When building within Meta's source tree, a number of OSS-only source files live in an
+# "oss/" sub-folder next to the main vrs/ folder that contains vrs' main source code.
+if ("${VRS_SOURCE_DIR}" STREQUAL "")
+  # open source layout
+  set(VRS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+  set(OSS_DIR "${VRS_SOURCE_DIR}")
 endif()
-
 
 set(CMAKE_MODULE_PATH "${OSS_DIR}/cmake")
 
@@ -48,14 +44,6 @@ include(${CMAKE_MODULE_PATH}/LibrariesSetup.cmake)
 
 # Include the libraries
 add_subdirectory(vrs)
-add_subdirectory(vrs/helpers)
-add_subdirectory(vrs/os)
-add_subdirectory(vrs/utils)
-add_subdirectory(vrs/utils/xxhash)
-add_subdirectory(vrs/utils/cli)
-
-# Include oss replacement libraries
-add_subdirectory(vrs/oss)
 
 # Add the sample apps/code
 add_subdirectory(sample_apps)

--- a/vrs/CMakeLists.txt
+++ b/vrs/CMakeLists.txt
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-file (GLOB VRS_SRCS *.cpp *.h *.hpp)
+add_subdirectory(helpers)
+add_subdirectory(os)
+add_subdirectory(oss)
+add_subdirectory(utils)
 
+file (GLOB VRS_SRCS *.cpp *.h *.hpp)
 add_library(vrslib STATIC ${VRS_SRCS})
 target_include_directories(vrslib PUBLIC ${VRS_SOURCE_DIR})
 target_link_libraries(vrslib

--- a/vrs/utils/CMakeLists.txt
+++ b/vrs/utils/CMakeLists.txt
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-file (GLOB VRS_UTILS_SRCS *.cpp *.h *.hpp)
+add_subdirectory(xxhash)
+add_subdirectory(cli)
 
+file (GLOB VRS_UTILS_SRCS *.cpp *.h *.hpp)
 add_library(vrs_utils STATIC ${VRS_UTILS_SRCS})
 target_link_libraries(vrs_utils
   PUBLIC


### PR DESCRIPTION
Summary:
This is a minor simplification of how the CMakeLists.txt files are organize and handle Meta vs. OSS builds.
No significant behavior changes, this is simply moving definitions around.

Differential Revision: D35036676

