### PR TITLE
Add missing loggin macro

### DIFF
--- a/vrs/oss/logging/Log.cpp
+++ b/vrs/oss/logging/Log.cpp
@@ -17,6 +17,8 @@
 
 #include <fmt/color.h>
 
+using namespace std;
+
 namespace vrs {
 namespace logging {
 
@@ -49,6 +51,16 @@ void log(Level level, const char* channel, const std::string& message) {
   } else {
     fmt::print(stderr, "[{}][{}]: {}\n", channel, logLevel, message);
   }
+}
+
+void log_every_n_seconds(
+    const char* file,
+    int line,
+    Level level,
+    int nSeconds,
+    const char* channel,
+    const std::string& message) {
+  log(level, channel, message);
 }
 
 } // namespace logging

--- a/vrs/oss/logging/Log.h
+++ b/vrs/oss/logging/Log.h
@@ -32,14 +32,39 @@ enum class Level {
   Debug = 3,
 };
 
+/// Logging backend: redirect where you need, depending on the log level and your preferences.
 void log(Level level, const char* channel, const std::string& message);
+
+/// Logging backend: redirect where you need, depending on the log level and your preferences
+/// This variant filters out too frequent output, based on the call site and a minimum duration
+/// between printouts.
+/// Warning: Currently does the same thing as regular logging (no time filtering yet).
+void log_every_n_seconds(
+    const char* file,
+    int line,
+    Level level,
+    int nSeconds,
+    const char* channel,
+    const std::string& message);
 
 } // namespace logging
 } // namespace vrs
 
 #define XR_LOG_DEFAULT(level, ...) log(level, DEFAULT_LOG_CHANNEL, fmt::format(__VA_ARGS__))
+#define XR_LOG_EVERY_N_SEC_DEFAULT(level, nseconds, ...) \
+  log_every_n_seconds(                                   \
+      __FILE__, __LINE__, level, nseconds, DEFAULT_LOG_CHANNEL, fmt::format(__VA_ARGS__))
 
 #define XR_LOGD(...) XR_LOG_DEFAULT(vrs::logging::Level::Debug, __VA_ARGS__)
 #define XR_LOGI(...) XR_LOG_DEFAULT(vrs::logging::Level::Info, __VA_ARGS__)
 #define XR_LOGW(...) XR_LOG_DEFAULT(vrs::logging::Level::Warning, __VA_ARGS__)
 #define XR_LOGE(...) XR_LOG_DEFAULT(vrs::logging::Level::Error, __VA_ARGS__)
+
+#define XR_LOGD_EVERY_N_SEC(nseconds, ...) \
+  XR_LOG_EVERY_N_SEC_DEFAULT(vrs::logging::Level::Debug, nseconds, __VA_ARGS__)
+#define XR_LOGI_EVERY_N_SEC(nseconds, ...) \
+  XR_LOG_EVERY_N_SEC_DEFAULT(vrs::logging::Level::Info, nseconds, __VA_ARGS__)
+#define XR_LOGW_EVERY_N_SEC(nseconds, ...) \
+  XR_LOG_EVERY_N_SEC_DEFAULT(vrs::logging::Level::Warning, nseconds, __VA_ARGS__)
+#define XR_LOGE_EVERY_N_SEC(nseconds, ...) \
+  XR_LOG_EVERY_N_SEC_DEFAULT(vrs::logging::Level::Error, nseconds, __VA_ARGS__)


### PR DESCRIPTION
Summary:
A recent diff added the use of the rarely needed XR_LOGW_EVERY_N_SEC, which broke OSS builds.
This diff is a quick fix until we can do a proper OSS implementation.

Differential Revision: D35274969

