### PR TITLE
Rename test targets to avoid ambiguity

### DIFF
--- a/tools/vrs/CMakeLists.txt
+++ b/tools/vrs/CMakeLists.txt
@@ -30,17 +30,17 @@ target_link_libraries(vrs
 if (UNIT_TESTS)
   enable_testing()
 
-  add_executable(test_ossvrs
+  add_executable(test_vrscli
     VrsCommand.cpp
     test/VrsAppTest.cpp
     test/VrsProcess.h
     test/VrsCommandTest.cpp
   )
-  target_include_directories(test_ossvrs
+  target_include_directories(test_vrscli
     PUBLIC
       ${CMAKE_CURRENT_SOURCE_DIR}/..
   )
-  target_link_libraries(test_ossvrs
+  target_link_libraries(test_vrscli
       PUBLIC
         vrs_os
         vrs_test_helpers
@@ -49,7 +49,7 @@ if (UNIT_TESTS)
         vrs_oss_testdatadir
         GTest::Main
   )
-  add_dependencies(test_ossvrs vrs)
+  add_dependencies(test_vrscli vrs)
 
-  gtest_discover_tests(test_ossvrs)
+  gtest_discover_tests(test_vrscli)
 endif()

--- a/vrs/test/CMakeLists.txt
+++ b/vrs/test/CMakeLists.txt
@@ -27,7 +27,7 @@ target_link_libraries(vrs_test_helpers
 )
 target_compile_definitions(vrs_test_helpers PUBLIC GTEST_BUILD)
 
-add_executable(test_vrs
+add_executable(test_vrslib
   ContentBlockReaderTest.cpp
   CustomBlockTest.cpp
   DataLayoutFormatTest.cpp
@@ -46,31 +46,31 @@ add_executable(test_vrs
   RecordTest.cpp
   TestProcessTest.cpp
 )
-target_link_libraries(test_vrs
+target_link_libraries(test_vrslib
     PUBLIC
       vrslib
       vrs_oss_testdatadir
       vrs_test_helpers
       GTest::Main
 )
-add_dependencies(test_vrs testedtool)
-target_compile_definitions(test_vrs PUBLIC GTEST_BUILD)
+add_dependencies(test_vrslib testedtool)
+target_compile_definitions(test_vrslib PUBLIC GTEST_BUILD)
 
-add_executable(test_vrs_file_tests
+add_executable(test_vrslib_file_tests
   file_tests/ChunkedFileTest.cpp
   file_tests/DeviceSimulatorTest.cpp
   file_tests/FileCacheTest.cpp
   file_tests/RecordableTest.cpp
   file_tests/SimpleFileHandlerTest.cpp
 )
-target_link_libraries(test_vrs_file_tests
+target_link_libraries(test_vrslib_file_tests
   PUBLIC
     vrslib
     vrs_oss_testdatadir
     vrs_test_helpers
     GTest::Main
 )
-target_compile_definitions(test_vrs_file_tests PUBLIC GTEST_BUILD)
+target_compile_definitions(test_vrslib_file_tests PUBLIC GTEST_BUILD)
 
-gtest_discover_tests(test_vrs)
-gtest_discover_tests(test_vrs_file_tests)
+gtest_discover_tests(test_vrslib)
+gtest_discover_tests(test_vrslib_file_tests)


### PR DESCRIPTION
Summary: There is vrs the library, with the cmake target name "vrslib", and "vrs" the command line tool, with the cmake targetname "vrs". The unit test apps associated with the two were too close and lead to confusion. This should remove all possibility of confusion.

Differential Revision: D35345076

