### PR TITLE
Enable find_package(vrslib) & install libraries and vrs binary (#40)

### DIFF
--- a/tools/vrs/CMakeLists.txt
+++ b/tools/vrs/CMakeLists.txt
@@ -15,11 +15,11 @@
 file(GLOB VRS_UTIL_SRCS *.cpp *.h)
 add_executable(vrs ${VRS_UTIL_SRCS})
 target_include_directories(vrs
-  PUBLIC
+  PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
 target_link_libraries(vrs
-  PUBLIC
+  PRIVATE
     vrslib
     vrs_utils
     vrs_utils_cli
@@ -27,6 +27,10 @@ target_link_libraries(vrs
     Png::Png
     Jpeg::Jpeg
     vrs_logging
+)
+
+install(TARGETS vrs EXPORT VRSLibTargets
+  RUNTIME DESTINATION bin
 )
 
 if (UNIT_TESTS)

--- a/vrs/CMakeLists.txt
+++ b/vrs/CMakeLists.txt
@@ -18,8 +18,12 @@ add_subdirectory(oss)
 add_subdirectory(utils)
 
 file (GLOB VRS_SRCS *.cpp *.h *.hpp)
-add_library(vrslib STATIC ${VRS_SRCS})
-target_include_directories(vrslib PUBLIC ${VRS_SOURCE_DIR})
+add_library(vrslib ${VRS_SRCS})
+target_include_directories(vrslib
+  PUBLIC
+  $<BUILD_INTERFACE:${VRS_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include>
+)
 target_link_libraries(vrslib
   PUBLIC
     vrs_helpers
@@ -28,6 +32,50 @@ target_link_libraries(vrslib
     vrs_utils_xxhash
     Lz4::Lz4
     Zstd::Zstd
+)
+
+install(TARGETS vrslib EXPORT VRSLibTargets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
+
+install(EXPORT VRSLibTargets
+  NAMESPACE vrs::
+  FILE vrslibTargets.cmake
+  DESTINATION lib/cmake/vrslib)
+
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(vrslibConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/vrslibConfig.cmake
+  INSTALL_DESTINATION ${LIB_INSTALL_DIR}/vrslib/cmake)
+
+
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/vrslibConfigVersion.cmake"
+  VERSION "1.0"
+  COMPATIBILITY AnyNewerVersion
+)
+
+install(
+  DIRECTORY .
+  DESTINATION include/vrs
+  COMPONENT headers
+  FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h"
+)
+
+install(
+  DIRECTORY ../cmake
+  DESTINATION lib/cmake/vrslib
+  FILES_MATCHING PATTERN "*.cmake"
+)
+
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/vrslibConfig.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/vrslibConfigVersion.cmake"
+  DESTINATION lib/cmake/vrslib
 )
 
 if (UNIT_TESTS)

--- a/vrs/helpers/CMakeLists.txt
+++ b/vrs/helpers/CMakeLists.txt
@@ -13,18 +13,34 @@
 # limitations under the License.
 
 add_library(vrs_helpers_strings INTERFACE)
-target_include_directories(vrs_helpers_strings INTERFACE ${VRS_SOURCE_DIR})
+target_include_directories(vrs_helpers_strings
+  INTERFACE
+  $<BUILD_INTERFACE:${VRS_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include>
+)
 
 file(GLOB VRS_HELPERS_SRCS *.cpp *.h *.hpp)
 
-add_library(vrs_helpers STATIC ${VRS_HELPERS_SRCS})
+add_library(vrs_helpers ${VRS_HELPERS_SRCS})
 target_link_libraries(vrs_helpers
-    PUBLIC
+    PRIVATE
         vrs_helpers_strings
+    PUBLIC
         vrs_os
         Cereal::Cereal
 )
-target_include_directories(vrs_helpers PUBLIC ${VRS_SOURCE_DIR})
+target_include_directories(vrs_helpers
+  PUBLIC
+  $<BUILD_INTERFACE:${VRS_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include>
+)
+
+install(TARGETS vrs_helpers vrs_helpers_strings EXPORT VRSLibTargets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
 
 if (UNIT_TESTS)
   enable_testing()

--- a/vrs/os/CMakeLists.txt
+++ b/vrs/os/CMakeLists.txt
@@ -19,10 +19,15 @@ if (VRS_OS_FB_SRCS)
   list(REMOVE_ITEM VRS_OS_SRCS ${VRS_OS_FB_SRCS})
 endif()
 
-add_library(vrs_os STATIC ${VRS_OS_SRCS})
-target_include_directories(vrs_os PUBLIC ${VRS_SOURCE_DIR})
+add_library(vrs_os ${VRS_OS_SRCS})
+target_include_directories(vrs_os
+  PUBLIC
+  $<BUILD_INTERFACE:${VRS_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include>
+)
+
 target_link_libraries(vrs_os
-    PUBLIC
+    PRIVATE
         vrs_platform
         vrs_logging
         Boost::system
@@ -31,11 +36,23 @@ target_link_libraries(vrs_os
         Boost::chrono
         Boost::date_time
 )
+target_compile_definitions(vrs_os INTERFACE OSS_BUILD_MODE)
 
 add_library(vrs_platform INTERFACE)
-target_include_directories(vrs_platform INTERFACE ${VRS_SOURCE_DIR})
+target_include_directories(vrs_platform
+  INTERFACE
+  $<BUILD_INTERFACE:${VRS_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include>
+)
 # When building with cmake, always enable OSS build mode
 target_compile_definitions(vrs_platform INTERFACE OSS_BUILD_MODE)
+
+install(TARGETS vrs_os vrs_platform EXPORT VRSLibTargets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
 
 if (UNIT_TESTS)
   enable_testing()

--- a/vrs/oss/TestDataDir/CMakeLists.txt
+++ b/vrs/oss/TestDataDir/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 file (GLOB VRS_OSS_TESTDATADIR *.cpp *.h)
 
-add_library(vrs_oss_testdatadir STATIC ${VRS_OSS_TESTDATADIR})
+add_library(vrs_oss_testdatadir ${VRS_OSS_TESTDATADIR})
 target_include_directories(vrs_oss_testdatadir PUBLIC ${VRS_SOURCE_DIR}/vrs/oss)
 target_link_libraries(vrs_oss_testdatadir
   PUBLIC

--- a/vrs/oss/logging/CMakeLists.txt
+++ b/vrs/oss/logging/CMakeLists.txt
@@ -17,10 +17,22 @@
 
 file (GLOB VRS_LOGGING_SRCS *.cpp *.h *.hpp)
 
-add_library(vrs_logging STATIC ${VRS_LOGGING_SRCS})
-target_include_directories(vrs_logging PUBLIC ${VRS_SOURCE_DIR}/vrs/oss)
+add_library(vrs_logging ${VRS_LOGGING_SRCS})
+target_include_directories(vrs_logging
+  INTERFACE
+  $<BUILD_INTERFACE:${VRS_SOURCE_DIR}/vrs/oss>
+  $<INSTALL_INTERFACE:include>
+)
+
 target_link_libraries(vrs_logging
     PUBLIC
         vrs_platform
         Fmt::Fmt
+)
+
+install(TARGETS vrs_logging EXPORT VRSLibTargets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
 )

--- a/vrs/oss/portability/CMakeLists.txt
+++ b/vrs/oss/portability/CMakeLists.txt
@@ -15,9 +15,18 @@
 # This library is a minimal replacement for the portability library used at Meta.
 
 add_library(vrs_oss_portability INTERFACE)
-set_target_properties(
-  vrs_oss_portability PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES ${VRS_SOURCE_DIR}/vrs/oss)
+target_include_directories(
+  vrs_oss_portability
+  INTERFACE
+    $<BUILD_INTERFACE:${VRS_SOURCE_DIR}/vrs/oss>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_link_libraries(vrs_oss_portability
   INTERFACE
     Boost::filesystem)
+
+install(TARGETS vrs_oss_portability EXPORT VRSLibTargets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)

--- a/vrs/utils/CMakeLists.txt
+++ b/vrs/utils/CMakeLists.txt
@@ -23,15 +23,27 @@ if (VRS_UTILS_FB_SRCS)
   list(REMOVE_ITEM VRS_UTILS_SRCS ${VRS_UTILS_FB_SRCS})
 endif()
 
-add_library(vrs_utils STATIC ${VRS_UTILS_SRCS})
+add_library(vrs_utils ${VRS_UTILS_SRCS})
 target_link_libraries(vrs_utils
-  PUBLIC
+  PRIVATE
     vrslib
     vrs_helpers
     vrs_utils_converters
-    Cereal::Cereal
     Fmt::Fmt
     Jpeg::Jpeg
     Png::Png
+    Cereal::Cereal
+    vrs_logging
 )
-target_include_directories(vrs_utils PUBLIC ${VRS_SOURCE_DIR})
+target_include_directories(vrs_utils
+  INTERFACE
+  $<BUILD_INTERFACE:${VRS_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include>
+)
+
+install(TARGETS vrs_utils EXPORT VRSLibTargets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)

--- a/vrs/utils/cli/CMakeLists.txt
+++ b/vrs/utils/cli/CMakeLists.txt
@@ -14,10 +14,12 @@
 
 file (GLOB VRS_UTILS_CLI_SRCS *.cpp *.h *.hpp)
 
-add_library(vrs_utils_cli STATIC ${VRS_UTILS_CLI_SRCS})
+add_library(vrs_utils_cli ${VRS_UTILS_CLI_SRCS})
 target_include_directories(vrs_utils_cli PUBLIC ${VRS_SOURCE_DIR})
 target_link_libraries(vrs_utils_cli
   PUBLIC
-    vrs_helpers
     vrs_utils
+  PRIVATE
+    vrs_helpers
+    vrs_logging
 )

--- a/vrs/utils/converters/CMakeLists.txt
+++ b/vrs/utils/converters/CMakeLists.txt
@@ -13,13 +13,23 @@
 # limitations under the License.
 
 file (GLOB VRS_UTILS_CONVERTERS_SRCS *.cpp *.h *.hpp)
-add_library(vrs_utils_converters STATIC ${VRS_UTILS_CONVERTERS_SRCS})
+add_library(vrs_utils_converters ${VRS_UTILS_CONVERTERS_SRCS})
 target_link_libraries(vrs_utils_converters
-  PUBLIC
+  PRIVATE
     vrs_logging
     vrs_os
 )
-target_include_directories(vrs_utils_converters PUBLIC ${VRS_SOURCE_DIR})
+target_include_directories(vrs_utils_converters
+  PUBLIC
+  $<BUILD_INTERFACE:${VRS_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+install(TARGETS vrs_utils_converters EXPORT VRSLibTargets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
 
 if (UNIT_TESTS)
   enable_testing()

--- a/vrs/utils/xxhash/CMakeLists.txt
+++ b/vrs/utils/xxhash/CMakeLists.txt
@@ -14,12 +14,22 @@
 
 file (GLOB VRS_XXHASH_SRCS *.cpp *.h *.hpp)
 
-add_library(vrs_utils_xxhash STATIC ${VRS_XXHASH_SRCS})
-target_include_directories(vrs_utils_xxhash PUBLIC ${VRS_SOURCE_DIR})
-target_link_libraries(vrs_utils_xxhash
+add_library(vrs_utils_xxhash ${VRS_XXHASH_SRCS})
+target_include_directories(vrs_utils_xxhash
   PUBLIC
+  $<BUILD_INTERFACE:${VRS_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+target_link_libraries(vrs_utils_xxhash
+  PRIVATE
     vrs_logging
     xxHash::xxHash
+)
+install(TARGETS vrs_utils_xxhash EXPORT VRSLibTargets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
 )
 
 if (UNIT_TESTS)

--- a/vrs/vrslibConfig.cmake.in
+++ b/vrs/vrslibConfig.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+set(PACKAGE_VERSION "1.0")
+include("${CMAKE_CURRENT_LIST_DIR}/vrslibTargets.cmake")
+
+# Library setup
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/LibrariesSetup.cmake)


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/vrs/pull/40

Add vrs_ libs to vrs::namespace
- Set some libs dependencies as PRIVATE
- Remove keyword STATIC, since it is the default behavior
- Add rules for installation and usage with cmake find_package(vrslib)
  - Since vrslib is using IMPORTED cmake targets (::) we don't know if they are static or dynamic. We so need to retrieve at find_package all vrs dependencies on the fly.

How to use it then in cmake:
```
find_package(vrslib REQUIRED)
add_executable(foo foo.cpp)
target_link_libraries(foo vrs::vrslib vrs::vrs_utils)
#vrs includes and dependencies will come transitively
```

Differential Revision: D35664218

