### PR TITLE
Add OSS license

### DIFF
--- a/vrs/vrslibConfig.cmake.in
+++ b/vrs/vrslibConfig.cmake.in
@@ -1,3 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @PACKAGE_INIT@
 set(PACKAGE_VERSION "1.0")
 include("${CMAKE_CURRENT_LIST_DIR}/vrslibTargets.cmake")


### PR DESCRIPTION
Summary: This file is missing the OSS license, as reported by the Automated Repo Checkup tool.

Reviewed By: SeaOtocinclus

Differential Revision: D36075408

