### PR TITLE
New JobQueue::waitForJob() method & enabled improvements

### DIFF
--- a/vrs/RecordFileWriter.cpp
+++ b/vrs/RecordFileWriter.cpp
@@ -102,12 +102,10 @@ class CompressionWorker {
   void threadActivity() {
     initCreatedThreadCallback_(thread_, ThreadRole::Compression, threadIndex_);
 
-    while (!workQueue_.hasEnded()) {
-      CompressionJob* job;
-      if (workQueue_.waitForJob(job, 1 /* second */)) {
-        job->performJob();
-        resultsQueue_.sendJob(job);
-      }
+    CompressionJob* job;
+    while (workQueue_.waitForJob(job)) {
+      job->performJob();
+      resultsQueue_.sendJob(job);
     }
   }
 

--- a/vrs/helpers/JobQueue.h
+++ b/vrs/helpers/JobQueue.h
@@ -46,6 +46,7 @@ class JobQueue {
     queue_.emplace_back(std::move(value));
     condition_.notify_one();
   }
+  /// Wait for a job up to a specified wait time, or until the queue was ended
   bool waitForJob(T& outValue, double waitTime) {
     if (waitTime <= 0) {
       return getJob(outValue);
@@ -63,6 +64,16 @@ class JobQueue {
     queue_.pop_front();
     return true;
   }
+  /// Wait for a job until one is available, or the queue was ended
+  bool waitForJob(T& outValue) {
+    while (!hasEnded_) {
+      if (waitForJob(outValue, 5)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  /// get a pending job, if any, but don't wait
   bool getJob(T& outValue) {
     std::unique_lock<std::mutex> locker(mutex_);
     if (queue_.empty()) {

--- a/vrs/helpers/JobQueue.h
+++ b/vrs/helpers/JobQueue.h
@@ -47,6 +47,9 @@ class JobQueue {
     condition_.notify_one();
   }
   bool waitForJob(T& outValue, double waitTime) {
+    if (waitTime <= 0) {
+      return getJob(outValue);
+    }
     double limit = os::getTimestampSec() + waitTime;
     std::unique_lock<std::mutex> locker(mutex_);
     double actualWaitTime;


### PR DESCRIPTION
Summary:
This new JobQueue::waitForJob() without a timeout method helps simplify a lot of code, as we can now often remove a while loop or an explicit test.
This diff updates all the call sites that could be improved in our code base, which should clearly demonstrate the better code patterns.

Differential Revision: D36917097

