### PR TITLE
Move core vrsplayer's code to oss/player

### DIFF
--- a/tools/vrsplayer/AudioPlayer.cpp
+++ b/tools/vrsplayer/AudioPlayer.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "AudioPlayer.h"
+
+#include <vector>
+
+#include <portaudio.h>
+
+#define DEFAULT_LOG_CHANNEL "AudioPlayer"
+#include <logging/Log.h>
+#include <logging/Verify.h>
+
+#include <vrs/RecordReaders.h>
+#include <vrs/StreamPlayer.h>
+
+#include "FileReader.h"
+#include "VideoTime.h"
+
+namespace vrsp {
+
+using namespace std;
+using namespace vrs;
+
+AudioPlayer::AudioPlayer(QObject* parent) : QObject(parent) {
+  failedInit_ = !XR_VERIFY(Pa_Initialize() == paNoError);
+}
+
+AudioPlayer::~AudioPlayer() {
+  playbackQueue_.endThread();
+  if (paStream_ != nullptr) {
+    VideoTime::setTimeAudioStreamSource(nullptr);
+    Pa_StopStream(paStream_);
+    Pa_CloseStream(paStream_);
+  }
+  Pa_Terminate();
+}
+
+bool vrsp::AudioPlayer::onDataLayoutRead(const CurrentRecord&, size_t, DataLayout&) {
+  return true;
+}
+
+bool AudioPlayer::onAudioRead(const CurrentRecord& record, size_t blkIdx, const ContentBlock& cb) {
+  // XR_LOGI("Audio block: {:.3f} {}", record.timestamp, contentBlock.asString());
+  vector<uint8_t> buffer(cb.getBlockSize());
+  if (record.reader->read(buffer) == 0) {
+    if (!failedInit_) {
+      const auto& audio = cb.audio();
+      if (paStream_ == nullptr) {
+        // the first time around, we just setup the device & the clock, but we don't play anything
+        // The first data read happens when we load the file, so we don't want to hear it!
+        setupAudioOutput(cb);
+        fmt::print(
+            "Found '{} - {}': {}, {}\n",
+            record.streamId.getNumericName(),
+            record.streamId.getTypeName(),
+            getCurrentRecordFormatReader()->recordFormat.asString(),
+            audio.asString());
+      } else if (VideoTime::getPlaybackSpeed() <= 1) {
+        uint32_t sampleCount = audio.getSampleCount();
+        uint32_t srcChannelCount = audio.getChannelCount();
+        uint8_t bytesPerSample = audio.getBytesPerSample();
+        if (channelCount_ == srcChannelCount) {
+          playbackQueue_.sendJob(AudioJob(move(buffer), sampleCount, bytesPerSample));
+        } else {
+          const uint8_t* src = reinterpret_cast<const uint8_t*>(buffer.data());
+          uint8_t* dst = reinterpret_cast<uint8_t*>(buffer.data());
+          for (uint32_t sample = 0; sample < sampleCount; ++sample) {
+            memcpy(dst, src, channelCount_ * bytesPerSample);
+            src += srcChannelCount * bytesPerSample;
+            dst += channelCount_ * bytesPerSample;
+          }
+          playbackQueue_.sendJob(AudioJob(move(buffer), sampleCount, bytesPerSample));
+        }
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+void AudioPlayer::setupAudioOutput(const ContentBlock& contentBlock) {
+  const auto& audio = contentBlock.audio();
+
+  PaDeviceIndex defaultOutpuDeviceIndex = Pa_GetDefaultOutputDevice();
+  const PaDeviceInfo* info = Pa_GetDeviceInfo(defaultOutpuDeviceIndex);
+  channelCount_ = min<int>(audio.getChannelCount(), info->maxOutputChannels);
+
+  PaStreamParameters output;
+  output.device = defaultOutpuDeviceIndex;
+  output.channelCount = channelCount_;
+  output.sampleFormat = paCustomFormat;
+  switch (audio.getSampleFormat()) {
+    case AudioSampleFormat::S8:
+      output.sampleFormat = paInt8;
+      break;
+
+    case AudioSampleFormat::U8:
+      output.sampleFormat = paUInt8;
+      break;
+
+    case AudioSampleFormat::S16_LE:
+      output.sampleFormat = paInt16;
+      break;
+
+    case AudioSampleFormat::S24_LE:
+      output.sampleFormat = paInt24;
+      break;
+
+    case AudioSampleFormat::S32_LE:
+      output.sampleFormat = paInt32;
+      break;
+
+    case AudioSampleFormat::F32_LE:
+      output.sampleFormat = paFloat32;
+      break;
+
+    // Might need to implement some conversions, eventually...
+    case AudioSampleFormat::A_LAW:
+    case AudioSampleFormat::MU_LAW:
+    case AudioSampleFormat::U16_LE:
+    case AudioSampleFormat::U24_LE:
+    case AudioSampleFormat::U32_LE:
+    case AudioSampleFormat::F64_LE:
+    case AudioSampleFormat::S16_BE:
+    case AudioSampleFormat::S24_BE:
+    case AudioSampleFormat::S32_BE:
+    case AudioSampleFormat::U16_BE:
+    case AudioSampleFormat::U24_BE:
+    case AudioSampleFormat::U32_BE:
+    case AudioSampleFormat::F32_BE:
+    case AudioSampleFormat::F64_BE:
+    case AudioSampleFormat::COUNT:
+    case AudioSampleFormat::UNDEFINED:
+      failedInit_ = true;
+      XR_LOGE(
+          "Audio sample format {} not supported. Audio sample conversion required.",
+          contentBlock.asString());
+      return;
+  }
+  output.hostApiSpecificStreamInfo = nullptr;
+  output.suggestedLatency = (info != nullptr) ? info->defaultLowOutputLatency : 0;
+
+  PaError status =
+      Pa_OpenStream(&paStream_, nullptr, &output, audio.getSampleRate(), 0, 0, nullptr, nullptr);
+  if (status == paNoError && XR_VERIFY(paStream_ != nullptr)) {
+    status = Pa_StartStream(paStream_);
+    if (XR_VERIFY(status == paNoError)) {
+      XR_LOGI("Audio output '{}' configured for {}!", info->name, contentBlock.asString());
+      VideoTime::setTimeAudioStreamSource(paStream_);
+      playbackQueue_.startThread(&AudioPlayer::playbackThread, this);
+    } else {
+      failedInit_ = true;
+    }
+  } else {
+    failedInit_ = true;
+  }
+  if (failedInit_ && paStream_ != nullptr) {
+    Pa_StopStream(paStream_);
+    Pa_CloseStream(paStream_);
+    paStream_ = nullptr;
+  }
+  if (failedInit_) {
+    XR_LOGE("Failed to initialize audio device for {}", contentBlock.asString());
+  }
+}
+
+void AudioPlayer::mediaStateChanged(FileReaderState state) {
+  if (state != FileReaderState::Playing) {
+    playbackQueue_.cancelAllQueuedJobs();
+  }
+}
+
+void AudioPlayer::playbackThread() {
+  AudioJob job;
+  while (playbackQueue_.waitForJob(job)) {
+    uint32_t playedFrames = 0;
+    while (playedFrames < job.frameCount) {
+      uint32_t frameBatchSize = min<uint32_t>(job.frameCount - playedFrames, 512);
+      if (job.frameCount - playedFrames - frameBatchSize < 64) {
+        frameBatchSize = job.frameCount - playedFrames;
+      }
+      Pa_WriteStream(
+          paStream_,
+          job.samples.data() + playedFrames * job.frameSize * channelCount_,
+          frameBatchSize);
+      playedFrames += frameBatchSize;
+    }
+  }
+}
+
+} // namespace vrsp

--- a/tools/vrsplayer/AudioPlayer.h
+++ b/tools/vrsplayer/AudioPlayer.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <thread>
+
+#include <QtCore/qglobal.h>
+#include <qobject.h>
+
+#include <vrs/RecordFormatStreamPlayer.h>
+#include <vrs/helpers/JobQueue.h>
+
+enum class FileReaderState;
+
+typedef void PaStream;
+
+namespace vrsp {
+
+using ::vrs::ContentBlock;
+using ::vrs::CurrentRecord;
+using ::vrs::DataLayout;
+using ::vrs::RecordFormatStreamPlayer;
+using ::vrs::StreamId;
+using ::vrs::StreamPlayer;
+
+class AudioPlayer : public QObject, public RecordFormatStreamPlayer {
+  Q_OBJECT
+
+  struct AudioJob {
+    AudioJob() = default;
+    AudioJob(std::vector<uint8_t>&& samples, uint32_t frameCount, uint32_t frameSize)
+        : samples{move(samples)}, frameCount{frameCount}, frameSize{frameSize} {}
+    AudioJob(AudioJob&& job)
+        : samples{move(job.samples)}, frameCount{job.frameCount}, frameSize{job.frameSize} {}
+
+    AudioJob& operator=(AudioJob&& job) {
+      samples = move(job.samples);
+      frameCount = job.frameCount;
+      frameSize = job.frameSize;
+      return *this;
+    }
+    std::vector<uint8_t> samples;
+    uint32_t frameCount;
+    uint32_t frameSize;
+  };
+
+ public:
+  explicit AudioPlayer(QObject* parent = nullptr);
+  ~AudioPlayer() override;
+
+  bool onDataLayoutRead(const CurrentRecord&, size_t blockIndex, DataLayout&) override;
+  bool onAudioRead(const CurrentRecord&, size_t blockIndex, const ContentBlock&) override;
+
+  void setupAudioOutput(const ContentBlock& contentBlock);
+
+ signals:
+
+ public slots:
+  void mediaStateChanged(FileReaderState state);
+
+ private:
+  void playbackThread();
+
+  PaStream* paStream_ = nullptr;
+  bool failedInit_ = false;
+  int channelCount_ = 0;
+  vrs::JobQueueWithThread<AudioJob> playbackQueue_;
+};
+
+} // namespace vrsp

--- a/tools/vrsplayer/FileReader.cpp
+++ b/tools/vrsplayer/FileReader.cpp
@@ -1,0 +1,1165 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "FileReader.h"
+
+#include <algorithm>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+#include <qapplication.h>
+#include <qboxlayout.h>
+#include <qdesktopwidget.h>
+#include <qevent.h>
+#include <qjsonarray.h>
+#include <qjsondocument.h>
+#include <qjsonobject.h>
+#include <qprogressdialog.h>
+#include <qstring.h>
+
+#define DEFAULT_LOG_CHANNEL "FileReader"
+#include <logging/Log.h>
+
+#include <vrs/ErrorCode.h>
+#include <vrs/helpers/EnumStringConverter.h>
+#include <vrs/os/Utils.h>
+#include <vrs/utils/RecordFileInfo.h>
+
+#include "AudioPlayer.h"
+#include "PlayerUI.h"
+
+#define FIXED_3 fixed << setprecision(3)
+
+namespace {
+const char* sStateNames[] = {"UNDEFINED", "NO_MEDIA", "PAUSED", "PLAYING", "ERROR"};
+
+struct FileReaderStateConverter : public EnumStringConverter<
+                                      FileReaderState,
+                                      sStateNames,
+                                      COUNT_OF(sStateNames),
+                                      FileReaderState::Undefined,
+                                      FileReaderState::Undefined> {
+  static_assert(
+      cNamesCount == static_cast<size_t>(FileReaderState::Count),
+      "Missing FileReaderState name definitions");
+};
+
+QString kLastMaxPerRow("last_max_per_row");
+QString kVisibleStreams("visible_streams");
+QString kLastConfiguration("last_configuration");
+QString kLayoutPresets("layout_presets");
+
+class FlagKeeper {
+ public:
+  FlagKeeper(bool& flag) : flag_{flag}, finalValue_{flag_} {
+    flag_ = false;
+  }
+  FlagKeeper(bool& flag, bool finalValue) : flag_{flag}, finalValue_{finalValue} {
+    flag_ = false;
+  }
+  ~FlagKeeper() {
+    flag_ = finalValue_;
+  }
+
+ private:
+  bool& flag_;
+  bool finalValue_;
+};
+
+} // namespace
+
+using namespace std;
+using namespace vrs;
+
+namespace vrsp {
+
+const int32_t kPageSize = 10;
+const int32_t kBigPageSize = 100;
+
+static int64_t kReadCurrentFrame = DispatchAction(Action::ShowFrame).bundle();
+static int64_t kReadCurrentFrameFast = DispatchAction(Action::ShowFrameFast).bundle();
+static int64_t kReadPreviousFrame = DispatchAction(Action::ChangeFrame, -1).bundle();
+static int64_t kReadNextFrame = DispatchAction(Action::ChangeFrame, 1).bundle();
+static int64_t kReadPreviousPage = DispatchAction(Action::ChangeFrame, -kPageSize).bundle();
+static int64_t kReadNextPage = DispatchAction(Action::ChangeFrame, kPageSize).bundle();
+static int64_t kReadPreviousBigPage = DispatchAction(Action::ChangeFrame, -kBigPageSize).bundle();
+static int64_t kReadNextBigPage = DispatchAction(Action::ChangeFrame, kBigPageSize).bundle();
+
+FileReader::FileReader(QObject* parent) : QObject(parent) {
+  isSliderActive_ = false;
+  slowTimer_.setSingleShot(false);
+  connect(&slowTimer_, &QTimer::timeout, this, &FileReader::updatePosition);
+  slowTimer_.start(33);
+
+  // start background thread
+  thread_ = std::thread{[this]() mutable { this->playThreadActivity(); }};
+}
+
+FileReader::~FileReader() {
+  closeFile();
+  if (thread_.joinable()) {
+    runThread_ = false;
+    waitEvent_.dispatchEvent();
+    thread_.join();
+  }
+}
+
+bool FileReader::isAtBegin() const {
+  return fileReader_ != nullptr && nextRecord_ <= firstDataRecordIndex_;
+}
+
+bool FileReader::isAtEnd() const {
+  return fileReader_ != nullptr && nextRecord_ >= fileReader_->getIndex().size();
+}
+
+void FileReader::closeFile() {
+  stop();
+  if (fileConfig_) {
+    saveConfiguration();
+    fileConfig_.reset();
+  }
+  unique_lock<recursive_mutex> guard{mutex_};
+  fileReader_.reset();
+  imageReaders_.clear();
+  audioReaders_.clear();
+  lastReadRecords_.clear();
+  if (videoFrames_ != nullptr) {
+    clearLayout(videoFrames_, true);
+  }
+  lastMaxPerRow_ = 0;
+}
+
+class OpenProgressDialog : public ProgressLogger {
+  static const int kStepScale = 100;
+  static constexpr double kCancelCheckDelaySec = 0.1;
+
+ public:
+  OpenProgressDialog(PlayerUI* playerUi, const FileSpec& spec)
+      : progressDialog_("Opening...", "Cancel", 20, 100, playerUi) {
+    progressDialog_.setMinimumWidth(350);
+    progressDialog_.setWindowModality(Qt::WindowModal);
+    progressDialog_.setRange(0, stepCount_ * kStepScale);
+    if (!spec.isDiskFile()) {
+      logMessage("Opening from " + spec.fileHandlerName + "...");
+      progressDialog_.show();
+    }
+    nextCancelCheckTime_ = 0;
+    keepGoing_ = true;
+  }
+
+  bool shouldKeepGoing() override {
+    const double now = VideoTime::getRawTime();
+    if (now > nextCancelCheckTime_) {
+      qApp->processEvents(); // let the app breathe regularly, but not too frequently either
+      if (keepGoing_ && progressDialog_.wasCanceled()) {
+        keepGoing_ = false;
+      }
+      nextCancelCheckTime_ = now + kCancelCheckDelaySec;
+    }
+    return keepGoing_;
+  }
+
+  void setStepCount(int stepCount) override {
+    ProgressLogger::setStepCount(stepCount + 1);
+    progressDialog_.setRange(0, stepCount_ * kStepScale);
+  }
+
+ protected:
+  void logMessage(const string& message) override {
+    ProgressLogger::logMessage(message);
+    progressDialog_.setLabelText(QString().fromStdString(message));
+    qApp->processEvents();
+  }
+  void logError(const string& message) override {
+    ProgressLogger::logError(message);
+    progressDialog_.setLabelText(QString().fromStdString(message));
+    qApp->processEvents();
+  }
+  void updateStep(size_t progress, size_t maxProgress) override {
+    int v = stepNumber_ * kStepScale + static_cast<int>(progress * kStepScale / maxProgress);
+    progressDialog_.setValue(v);
+    qApp->processEvents();
+  }
+
+ private:
+  QProgressDialog progressDialog_;
+  double nextCancelCheckTime_;
+  bool keepGoing_;
+};
+
+static QString getFileName(const FileSpec& spec) {
+  if (!spec.fileName.empty()) {
+    return QString::fromStdString(spec.fileName);
+  }
+  if (spec.isDiskFile() && !spec.chunks.empty()) {
+    return QString::fromStdString(os::getFilename(spec.chunks.front()));
+  }
+  if (spec.chunks.size() == 1 && !spec.fileHandlerName.empty()) {
+    return QString::fromStdString(
+        os::getFilename(spec.chunks.front()) + " (" + spec.fileHandlerName + ")");
+  }
+  if (!spec.uri.empty()) {
+    return QString::fromStdString(spec.uri);
+  }
+  return QString::fromStdString(spec.toJson());
+}
+
+vector<FrameWidget*>
+FileReader::openFile(const QString& qpath, QVBoxLayout* videoFrame, QWidget* widget) {
+  closeFile();
+  string path = qpath.toStdString();
+  FileSpec spec;
+  if (spec.fromPathJsonUri(path) != 0) {
+    setErrorText("Can't open " + path);
+    return {};
+  }
+  unique_lock<recursive_mutex> guard{mutex_};
+  OpenProgressDialog progressUi(playerUi_, spec);
+  cout << "Loading " << path << "..." << endl;
+  fileReader_ = make_unique<RecordFileReader>();
+  widget->setWindowTitle(getFileName(spec));
+  int error = 0;
+  if (spec.isDiskFile()) {
+    error = fileReader_->openFile(spec);
+    if (error != 0) {
+      setErrorText(errorCodeToMessage(error));
+    }
+    isLocalFile_ = true;
+  } else {
+    fileReader_->setOpenProgressLogger(&progressUi);
+    double before = VideoTime::getRawTime();
+    error = fileReader_->openFile(spec);
+    if (progressUi.shouldKeepGoing()) {
+      if (error != 0) {
+        setErrorText(errorCodeToMessage(error));
+      }
+    } else {
+      emit statusStateChanged("Open Cancelled.");
+    }
+    isLocalFile_ = false;
+    cout << "Opened from " << spec.fileHandlerName << " in "
+         << helpers::humanReadableDuration(VideoTime::getRawTime() - before) << "." << endl;
+  }
+  if (error == 0) {
+    fileChanged(widget, spec);
+  } else {
+    setState(FileReaderState::Error);
+    videoFrames_ = nullptr;
+    return {};
+  }
+  RecordFileInfo::printOverview(cout, *fileReader_);
+  progressUi.logNewStep("Loading first frames");
+  return openFile(videoFrame, widget);
+}
+
+static void statsCallback(const FileHandler::CacheStats& stats) {}
+
+vector<FrameWidget*> FileReader::openFile(QVBoxLayout* videoFrames, QWidget* widget) {
+  FlagKeeper disableLayoutUpdates(layoutUpdatesEnabled_, true);
+  loadConfiguration();
+  vector<FrameWidget*> frames;
+  videoFrames_ = videoFrames;
+  setState(FileReaderState::Paused);
+  fileReader_->setStatsCallback(statsCallback);
+  const auto& index = fileReader_->getIndex();
+  if (!index.empty()) {
+    double startTime = numeric_limits<double>::max();
+    double endTime = numeric_limits<double>::lowest();
+    uint32_t firstDataRecordIndex = static_cast<uint32_t>(index.size());
+    const auto& ids = fileReader_->getStreams();
+    for (StreamId id : ids) {
+      if (imageReaders_.find(id) == imageReaders_.end()) {
+        bool mightContainImagesOrAudio = true;
+        if (fileReader_->mightContainImages(id)) {
+          FrameWidget* frame = new FrameWidget();
+          frame->setTypeToShow(recordType_);
+          FramePlayer* imageReader = new FramePlayer(id, frame);
+          fileReader_->setStreamPlayer(id, imageReader);
+          imageReaders_[id].reset(imageReader);
+          connect(frame, &FrameWidget::orientationChanged, [this]() {
+            if (layoutUpdatesEnabled_) {
+              relayout();
+            }
+          });
+          connect(frame, &FrameWidget::shouldHideStream, [this, id]() { this->disableStream(id); });
+          connect(
+              frame, &FrameWidget::shouldMoveBefore, [this, id]() { this->moveStream(id, true); });
+          connect(
+              frame, &FrameWidget::shouldMoveAfter, [this, id]() { this->moveStream(id, false); });
+          connect(
+              this, &FileReader::mediaStateChanged, imageReader, &FramePlayer::mediaStateChanged);
+          // decode first config & data record, to init the image size
+          readFirstRecord(id, Record::Type::CONFIGURATION);
+          readFirstRecord(id, Record::Type::STATE);
+          readFirstRecord(id, Record::Type::DATA);
+          frame->blank();
+          frame->setTags(fileReader_->getTags(id).user);
+          frame->setDeviceName(getDeviceName(id));
+          frames.push_back(frame);
+          mightContainImagesOrAudio = true;
+        } else if (fileReader_->mightContainAudio(id)) {
+          AudioPlayer* player = new AudioPlayer();
+          audioReaders_[id].reset(player);
+          fileReader_->setStreamPlayer(id, player);
+          connect(this, &FileReader::mediaStateChanged, player, &AudioPlayer::mediaStateChanged);
+          readFirstRecord(id, Record::Type::CONFIGURATION);
+          readFirstRecord(id, Record::Type::STATE);
+          readFirstRecord(id, Record::Type::DATA);
+          mightContainImagesOrAudio = true;
+        }
+        if (mightContainImagesOrAudio) {
+          // Update the time range we're interested in
+          const IndexRecord::RecordInfo* record = fileReader_->getRecord(id, Record::Type::DATA, 0);
+          if (record != nullptr) {
+            startTime = min<double>(startTime, record->timestamp);
+            uint32_t idx = fileReader_->getRecordIndex(record);
+            firstDataRecordIndex = min<uint32_t>(firstDataRecordIndex, idx);
+          }
+          record = fileReader_->getLastRecord(id, Record::Type::DATA);
+          if (record != nullptr && record->timestamp > endTime) {
+            endTime = record->timestamp;
+          }
+        }
+      }
+    }
+    restoreCurrentConfig();
+    sanitizeVisibleStreams();
+    setTimeRange(startTime, endTime, firstDataRecordIndex);
+    if (!imageReaders_.empty()) {
+      if (lastMaxPerRow_ != 0) {
+        relayout();
+      } else {
+        // Go over layout options, to find the one that matches the screen's aspect ratio the best
+        QSize screenSize = QApplication::desktop()->screenGeometry(widget).size();
+        float screenRatio = static_cast<float>(screenSize.width()) / screenSize.height();
+        // screenRatio = 1.77; // 24" monitor simulation
+        // screenRatio = 2560.0f / 1600; // 30" monitor simulation
+        float bestFactor = numeric_limits<float>::max();
+        int bestMaxHViews = 1;
+        for (int maxHviews = 1; maxHviews <= static_cast<int>(imageReaders_.size()); maxHviews++) {
+          int totalWidth = 0;
+          int totalHeight = 0;
+          int maxWidth = 0;
+          int maxHeight = 0;
+          int count = 0;
+          for (auto& image : imageReaders_) {
+            QSize imageSize = image.second->getWidget()->getImageSize();
+            totalWidth += imageSize.width();
+            maxHeight = max<int>(maxHeight, imageSize.height());
+            if (++count % maxHviews == 0) {
+              totalHeight += maxHeight;
+              maxWidth = max<int>(maxWidth, totalWidth);
+              maxHeight = 0;
+              totalWidth = 0;
+            }
+          }
+          int layoutHeight = totalHeight + maxHeight;
+          int layoutWidth = max<int>(maxWidth, totalWidth);
+          float ratio = static_cast<float>(layoutWidth) / layoutHeight;
+          float newFactor = ratio > screenRatio ? ratio / screenRatio : screenRatio / ratio;
+          // Give a boost if the last row has the same number of views as the previous rows
+          if (count % maxHviews == 0) {
+            newFactor = 1 + (newFactor - 1) * 0.2F;
+          }
+          if (newFactor < bestFactor) {
+            bestFactor = newFactor;
+            bestMaxHViews = maxHviews;
+          }
+        }
+        layoutFrames(videoFrames, widget, bestMaxHViews);
+      }
+    }
+  } else {
+    setTimeRange(0, 0, 0);
+  }
+  time_.setTime(startTime_);
+  nextRecord_ = firstDataRecordIndex_;
+  lastReadRecords_.clear();
+  emit mediaStateChanged(FileReaderState::Paused);
+  return frames;
+}
+
+void FileReader::setOverlayColor(QColor color) {
+  for (auto& image : imageReaders_) {
+    image.second->getWidget()->setOverlayColor(color);
+  }
+}
+
+void FileReader::recordTypeChanged(const QString& type) {
+  recordType_ = toEnum<Record::Type>(type.toStdString());
+  for (auto& image : imageReaders_) {
+    image.second->getWidget()->setTypeToShow(recordType_);
+  }
+}
+
+void FileReader::setPosition(int position) {
+  if (fileReader_ == nullptr) {
+    return;
+  }
+  unique_lock<recursive_mutex> guard{mutex_};
+  pause();
+  IndexRecord::RecordInfo seekTime;
+  seekTime.timestamp = positionToTime(position);
+  time_.setTime(seekTime.timestamp);
+  const auto& index = fileReader_->getIndex();
+  nextRecord_ =
+      static_cast<size_t>(lower_bound(index.begin(), index.end(), seekTime) - index.begin());
+  cout << "Seek to " << FIXED_3 << seekTime.timestamp << ", record #" << nextRecord_ << endl;
+  waitEvent_.dispatchEvent(isSliderActive_ ? kReadCurrentFrameFast : kReadCurrentFrame);
+}
+
+void FileReader::sliderPressed() {
+  isSliderActive_ = true;
+  setBlankMode(false);
+}
+
+void FileReader::sliderReleased() {
+  isSliderActive_ = false;
+  waitEvent_.dispatchEvent(kReadCurrentFrame);
+}
+
+bool FileReader::eventFilter(QObject* obj, QEvent* event) {
+  if (playerUi_ != nullptr && playerUi_->isActiveWindow() && event->type() == QEvent::KeyPress) {
+    QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+    switch (keyEvent->key()) {
+      case Qt::Key_Space:
+        if (state_ == FileReaderState::Playing) {
+          pause();
+        } else if (state_ == FileReaderState::Paused) {
+          play();
+        }
+        return true;
+
+      case Qt::Key_Left:
+        if (state_ == FileReaderState::Paused) {
+          previousFrame();
+        }
+        return true;
+
+      case Qt::Key_Right:
+        if (state_ == FileReaderState::Paused) {
+          nextFrame();
+        }
+        return true;
+
+      case Qt::Key_Home:
+        if (state_ == FileReaderState::Paused || state_ == FileReaderState::Playing) {
+          stop();
+        }
+        return true;
+
+      case Qt::Key_Up:
+        if (state_ == FileReaderState::Paused) {
+          waitEvent_.dispatchEvent(kReadPreviousPage);
+        }
+        return true;
+
+      case Qt::Key_Down:
+        if (state_ == FileReaderState::Paused) {
+          waitEvent_.dispatchEvent(kReadNextPage);
+        }
+        return true;
+
+      case Qt::Key_PageUp:
+        if (state_ == FileReaderState::Paused) {
+          waitEvent_.dispatchEvent(kReadPreviousBigPage);
+        }
+        return true;
+
+      case Qt::Key_PageDown:
+        if (state_ == FileReaderState::Paused) {
+          waitEvent_.dispatchEvent(kReadNextBigPage);
+        }
+        return true;
+
+      case Qt::Key_Backspace:
+        stop();
+        return true;
+
+      case Qt::Key_Plus:
+        emit adjustSpeed(1);
+        return true;
+
+      case Qt::Key_Minus:
+        emit adjustSpeed(-1);
+        return true;
+
+      case Qt::Key_Equal:
+        emit adjustSpeed(0);
+        return true;
+
+      default:
+        return QObject::eventFilter(obj, event);
+    }
+  }
+  return QObject::eventFilter(obj, event);
+}
+
+void FileReader::stop() {
+  nextRecord_ = firstDataRecordIndex_; // setState needs this to highlight buttons right
+  if (state_ == FileReaderState::Playing) {
+    setState(FileReaderState::Paused);
+    unique_lock<recursive_mutex> guard{mutex_};
+    if (fileReader_ != nullptr) {
+      fileReader_->setCachingStrategy(CachingStrategy::Streaming);
+    }
+    lastReadRecords_.clear();
+  } else {
+    mediaStateChanged(state_);
+  }
+  time_.setTime(startTime_);
+  nextRecord_ = firstDataRecordIndex_; // against races
+  setBlankMode(true);
+}
+
+void FileReader::setBlankMode(bool blank) {
+  for (auto& image : imageReaders_) {
+    image.second->setBlankMode(blank);
+  }
+  unique_lock<recursive_mutex> guard{mutex_};
+  lastReadRecords_.clear();
+}
+
+void FileReader::clearLayout(QLayout* layout, bool deleteWidgets) {
+  QLayoutItem* child;
+  while ((child = layout->takeAt(0)) != nullptr) {
+    if (child->layout() != nullptr) {
+      clearLayout(child->layout(), deleteWidgets);
+    }
+    if (deleteWidgets) {
+      delete child->widget();
+    }
+    delete child;
+  }
+}
+
+void FileReader::readFirstRecord(StreamId id, Record::Type recordType) {
+  const IndexRecord::RecordInfo* record = fileReader_->getRecord(id, recordType, 0);
+  if (record != nullptr && recordType == Record::Type::DATA) {
+    const IndexRecord::RecordInfo* config =
+        fileReader_->getRecord(id, Record::Type::CONFIGURATION, 0);
+    if (config != nullptr && config->timestamp > record->timestamp) {
+      record = fileReader_->getRecordByTime(id, recordType, config->timestamp);
+    }
+  }
+  if (record != nullptr) {
+    int error = fileReader_->readRecord(*record);
+    if (error != 0) {
+      setState(FileReaderState::Error);
+      setErrorText(errorCodeToMessage(error));
+    }
+  }
+}
+
+void FileReader::setErrorText(const string& errorText) {
+  statusStateChanged(errorText.empty() ? "" : "Error: " + errorText);
+}
+
+bool FileReader::isAudio(StreamId id) const {
+  return audioReaders_.find(id) != audioReaders_.end();
+}
+
+bool FileReader::isVideo(StreamId id) const {
+  return imageReaders_.find(id) != imageReaders_.end();
+}
+
+bool FileReader::isVisibleVideo(StreamId id) const {
+  auto iter = imageReaders_.find(id);
+  return iter != imageReaders_.end() && iter->second->isVisible();
+}
+
+string FileReader::getDeviceName(StreamId id) {
+  string flavor = fileReader_->getFlavor(id);
+  if (flavor.empty()) {
+    return fmt::format("{} - {}", id.getNumericName(), id.getTypeName());
+  }
+  return fmt::format("{} - {}, {}", id.getNumericName(), id.getTypeName(), flavor);
+}
+
+void FileReader::sanitizeVisibleStreams(bool reset) {
+  reset |= visibleStreams_.empty();
+  set<StreamId> visibleIds;
+  if (!reset) {
+    for (auto id : visibleStreams_) {
+      if (imageReaders_.find(id) == imageReaders_.end() ||
+          visibleIds.find(id) != visibleIds.end()) {
+        reset = true;
+        break;
+      }
+      visibleIds.insert(id);
+    }
+  }
+  if (reset) {
+    visibleStreams_.clear();
+    visibleStreams_.reserve(imageReaders_.size());
+    for (const auto& r : imageReaders_) {
+      visibleStreams_.push_back(r.first);
+      r.second->setVisible(true);
+    }
+  } else {
+    for (const auto& r : imageReaders_) {
+      r.second->setVisible(visibleIds.find(r.first) != visibleIds.end());
+    }
+  }
+}
+
+static QString rotationName(const QString& streamName) {
+  return streamName + "_rotation";
+}
+
+static QString flippedName(const QString& streamName) {
+  return streamName + "_flipped";
+}
+
+QVariant FileReader::configurationAsVariant() {
+  QJsonObject values;
+  QJsonArray visibleStreams;
+  for (auto id : visibleStreams_) {
+    visibleStreams.append(QJsonValue(QString(fileToConfig_[id].getNumericName().c_str())));
+  }
+  values[kVisibleStreams] = visibleStreams;
+  for (const auto& reader : imageReaders_) {
+    QString streamName = fileToConfig_[reader.first].getNumericName().c_str();
+    values[rotationName(streamName)] = reader.second->getWidget()->getRotation();
+    values[flippedName(streamName)] = reader.second->getWidget()->getFlipped();
+  }
+  values[kLastMaxPerRow] = lastMaxPerRow_;
+  return QJsonDocument(values).toVariant();
+}
+
+void FileReader::applyConfiguration(const QVariant& variant) {
+  FlagKeeper disableRelayouts(layoutUpdatesEnabled_);
+  QJsonDocument config(QJsonDocument::fromVariant(variant));
+  map<StreamId, StreamId> settingsToFile;
+  for (const auto& m : fileToConfig_) {
+    settingsToFile[m.second] = m.first;
+  }
+  visibleStreams_.clear();
+  const QJsonArray& visibleStreams = config[kVisibleStreams].toArray();
+  visibleStreams_.reserve(visibleStreams.size());
+  for (const auto& value : visibleStreams) {
+    StreamId id = StreamId::fromNumericName(value.toString().toStdString());
+    if (id.isValid() && settingsToFile.count(id) == 1) {
+      visibleStreams_.push_back(settingsToFile[id]);
+    }
+  }
+  for (const auto& reader : imageReaders_) {
+    QString streamName = fileToConfig_[reader.first].getNumericName().c_str();
+    reader.second->getWidget()->setRotation(config[rotationName(streamName)].toInt());
+    reader.second->getWidget()->setFlipped(config[flippedName(streamName)].toBool());
+  }
+  lastMaxPerRow_ = config[kLastMaxPerRow].toInt();
+}
+
+void FileReader::play() {
+  if (fileReader_ != nullptr && state_ == FileReaderState::Paused && !isAtEnd()) {
+    setState(FileReaderState::Playing);
+  }
+}
+
+double FileReader::getNextRecordDelay() {
+  if (state_ == FileReaderState::Playing) {
+    unique_lock<recursive_mutex> guard{mutex_};
+    if (fileReader_ != nullptr && state_ == FileReaderState::Playing) {
+      const auto& index = fileReader_->getIndex();
+      // find the next record in a stream we care about
+      while (nextRecord_ < index.size()) {
+        if (isPlaying(index[nextRecord_].streamId)) {
+          return index[nextRecord_].timestamp - time_.getTime();
+        }
+        nextRecord_++;
+      }
+    }
+  }
+  return 1; // just wait
+}
+
+void FileReader::playThreadActivity() {
+  EventChannel::Event event;
+  while (runThread_) {
+    double delay = getNextRecordDelay();
+    if (delay > 0) {
+      if (waitEvent_.waitForEvent(event, delay) == EventChannel::Status::SUCCESS &&
+          event.value != 0) {
+        playAction(DispatchAction::fromBundle(event.value));
+        continue;
+      }
+    }
+    if (state_ == FileReaderState::Playing) {
+      unique_lock<recursive_mutex> guard{mutex_};
+      if (fileReader_ != nullptr && state_ == FileReaderState::Playing) {
+        const auto& index = fileReader_->getIndex();
+        const IndexRecord::RecordInfo& record = index[nextRecord_];
+        double now = time_.getTime();
+        bool mustPlay = isAudio(record.streamId) || record.recordType != Record::Type::DATA;
+        if (mustPlay ||
+            (now < record.timestamp + kMaxPlaybackAge && isVisibleVideo(record.streamId))) {
+          if ((isLocalFile_ || fileReader_->isRecordAvailableOrPrefetch(record))) {
+            readRecordIfNeeded(record, nextRecord_, false);
+          }
+          nextRecord_++;
+        } else {
+          while (++nextRecord_ < index.size()) {
+            const IndexRecord::RecordInfo& next = index[nextRecord_];
+            // skip irrelevant records & late images
+            mustPlay = isAudio(next.streamId) || next.recordType != Record::Type::DATA;
+            if (mustPlay || (now < next.timestamp && isVisibleVideo(next.streamId))) {
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+int FileReader::readRecordIfNeeded(
+    const vrs::IndexRecord::RecordInfo& record,
+    size_t recordIndex,
+    bool log) {
+  size_t& lastPlayed = lastReadRecords_[record.streamId];
+  if (lastPlayed == recordIndex) {
+    return 0;
+  }
+  if (log) {
+    fmt::print(
+        "Reading {} record #{}, {} - {}\n",
+        toString(record.recordType),
+        recordIndex,
+        record.streamId.getNumericName(),
+        record.streamId.getTypeName());
+  }
+  int error = fileReader_->readRecord(record);
+  if (error != 0) {
+    setState(FileReaderState::Error);
+    setErrorText(errorCodeToMessage(error));
+    lastPlayed = fileReader_->getIndex().size();
+    return error;
+  }
+  lastPlayed = recordIndex;
+  return 0;
+}
+
+void FileReader::playAction(DispatchAction action) {
+  unique_lock<recursive_mutex> guard{mutex_};
+  fileReader_->setCachingStrategy(CachingStrategy::StreamingBidirectional);
+  set<size_t> frameSet;
+  if (action.action == Action::ShowFrame) {
+    if (getFrameSet(frameSet, nextRecord_, Direction::Backward)) {
+      playFrameSet(frameSet, Seek::Accurate);
+    }
+  } else if (action.action == Action::ShowFrameFast) {
+    if (getFrameSet(frameSet, nextRecord_, Direction::Backward)) {
+      playFrameSet(frameSet, Seek::Fast);
+    }
+  } else if (action.action == Action::ChangeFrame) {
+    setBlankMode(false);
+    int32_t actionCount = action.frameCount;
+    Direction direction = (action.frameCount > 0) ? Direction::Forward : Direction::Backward;
+    if (direction == Direction::Backward) {
+      actionCount = -actionCount + 1; // because we need to skip the last set read
+    }
+    while (actionCount-- > 0 && getFrameSet(frameSet, nextRecord_, direction)) {
+      nextRecord_ = direction == Direction::Forward ? *frameSet.rbegin() + 1 : *frameSet.begin();
+    }
+    const auto& index = fileReader_->getIndex();
+    if (frameSet.empty()) {
+      if (direction == Direction::Forward) {
+        // Read last possible set
+        nextRecord_ = index.size();
+        getFrameSet(frameSet, nextRecord_, Direction::Backward);
+      } else {
+        stop();
+      }
+    } else {
+      // even going backwards, the next record is after what we read
+      nextRecord_ = *frameSet.rbegin() + 1;
+    }
+    if (!frameSet.empty()) {
+      playFrameSet(frameSet, Seek::Accurate);
+      size_t lastPlayed = *frameSet.rbegin();
+      time_.setTime(index[lastPlayed].timestamp);
+    }
+  }
+  mediaStateChanged(state_);
+}
+
+// Helper to prefetch a frameset, making sure we cancel the sequence on exit
+class Prefetcher {
+ public:
+  Prefetcher(RecordFileReader& reader, const set<size_t>& frameSet, bool isLocalFile)
+      : reader_{reader} {
+    if (!isLocalFile) {
+      const auto& index = reader_.getIndex();
+      records_.reserve(frameSet.size());
+      for (size_t frameIndex : frameSet) {
+        records_.emplace_back(&index[frameIndex]);
+      }
+      reader_.prefetchRecordSequence(records_);
+    }
+  }
+  ~Prefetcher() {
+    if (!records_.empty()) {
+      records_.clear();
+      reader_.prefetchRecordSequence(records_);
+    }
+  }
+
+ private:
+  RecordFileReader& reader_;
+  vector<const IndexRecord::RecordInfo*> records_;
+};
+
+bool FileReader::playFrameSet(const set<size_t>& frameSet, Seek strategy) {
+  Prefetcher prefetcher(*fileReader_, frameSet, isLocalFile_);
+  const auto& index = fileReader_->getIndex();
+  for (size_t frame : frameSet) {
+    const IndexRecord::RecordInfo& record = index[frame];
+    if (strategy == Seek::Fast && !fileReader_->isRecordAvailableOrPrefetch(record)) {
+      continue;
+    }
+    if (readRecordIfNeeded(record, frame, true) != 0) {
+      return false;
+    }
+    FramePlayer* framePlayer = imageReaders_[record.streamId].get();
+    if (framePlayer != nullptr && (isLocalFile_ || strategy == Seek::Accurate)) {
+      int result = framePlayer->readMissingFrames(*fileReader_, record, strategy == Seek::Accurate);
+      if (result != SUCCESS) {
+        setState(FileReaderState::Error);
+        if (result == FAILURE) {
+          setErrorText("Can't find keyframe record for " + record.streamId.getName());
+        } else {
+          setErrorText(errorCodeToMessage(result));
+        }
+      }
+    }
+  }
+  return true;
+}
+
+bool FileReader::getFrameSet(set<size_t>& outSet, size_t start, Direction direction) const {
+  outSet.clear();
+  set<StreamId> ids;
+  const auto& index = fileReader_->getIndex();
+  size_t nextFrame = start;
+  while (true) {
+    if (direction == Direction::Backward) {
+      if (nextFrame == 0) {
+        break;
+      }
+      nextFrame--;
+    }
+    if (nextFrame >= index.size()) {
+      break;
+    }
+    const IndexRecord::RecordInfo& record = index[nextFrame];
+    StreamId id = index[nextFrame].streamId;
+    if (isVisibleVideo(id)) {
+      if (record.recordType == Record::Type::DATA && !ids.insert(id).second) {
+        break; // we've seen that device already: stop the set
+      }
+      outSet.insert(nextFrame);
+    }
+    if (direction == Direction::Forward) {
+      nextFrame++;
+    }
+  }
+  return !outSet.empty();
+}
+
+void FileReader::pause() {
+  if (state_ == FileReaderState::Playing) {
+    setState(FileReaderState::Paused);
+    waitEvent_.dispatchEvent(kReadCurrentFrame);
+  }
+}
+
+void FileReader::nextFrame() {
+  setBlankMode(false);
+  waitEvent_.dispatchEvent(kReadNextFrame);
+}
+
+void FileReader::previousFrame() {
+  setBlankMode(false);
+  waitEvent_.dispatchEvent(kReadPreviousFrame);
+}
+
+void FileReader::updatePosition() {
+  unique_lock<recursive_mutex> guard{mutex_};
+  if (fileReader_ == nullptr || (imageReaders_.empty() && audioReaders_.empty())) {
+    lastShownTime_ = std::numeric_limits<double>::quiet_NaN();
+    timeChanged(0, 0);
+  } else {
+    if (state_ == FileReaderState::Playing && nextRecord_ >= fileReader_->getIndex().size()) {
+      cout << "End of file reached" << endl;
+      pause();
+    }
+    double time = time_.getTime();
+    if (time != lastShownTime_) {
+      lastShownTime_ = time;
+      timeChanged(time, timeToPosition(time));
+    }
+  }
+}
+
+void FileReader::setPlaybackSpeed(double speed) {
+  if (state_ == FileReaderState::Playing) {
+    setState(FileReaderState::Paused);
+    VideoTime::setPlaybackSpeed(speed);
+    setState(FileReaderState::Playing);
+  } else {
+    VideoTime::setPlaybackSpeed(speed);
+  }
+}
+
+void FileReader::enableAllStreams() {
+  FlagKeeper disableRelayouts(layoutUpdatesEnabled_);
+  for (const auto& reader : imageReaders_) {
+    if (!reader.second->isVisible()) {
+      reader.second->setVisible(!reader.second->isVisible());
+      visibleStreams_.push_back(reader.first);
+    }
+  }
+  relayout();
+  waitEvent_.dispatchEvent(kReadCurrentFrame);
+}
+
+void FileReader::resetOrientation() {
+  FlagKeeper disableRelayouts(layoutUpdatesEnabled_);
+  for (const auto& reader : imageReaders_) {
+    reader.second->getWidget()->resetOrientation();
+  }
+  relayout();
+}
+
+void FileReader::toggleVisibleStreams() {
+  FlagKeeper disableRelayouts(layoutUpdatesEnabled_);
+  visibleStreams_.clear();
+  for (const auto& reader : imageReaders_) {
+    reader.second->setVisible(!reader.second->isVisible());
+    if (reader.second->isVisible()) {
+      visibleStreams_.push_back(reader.first);
+    }
+  }
+  relayout();
+  waitEvent_.dispatchEvent(kReadCurrentFrame);
+}
+
+void FileReader::disableStream(StreamId id) {
+  assert(imageReaders_.find(id) != imageReaders_.end());
+  for (auto iter = visibleStreams_.begin(); iter != visibleStreams_.end(); ++iter) {
+    if (*iter == id) {
+      visibleStreams_.erase(iter);
+      imageReaders_[id]->setVisible(false);
+      break;
+    }
+  }
+  relayout();
+}
+
+void FileReader::moveStream(StreamId id, bool beforeNotAfter) {
+  if (visibleStreams_.size() < 2) {
+    return;
+  }
+  for (size_t p = 0; p < visibleStreams_.size(); p++) {
+    if (visibleStreams_[p] == id) {
+      visibleStreams_.erase(visibleStreams_.begin() + p);
+      if (beforeNotAfter) {
+        if (p == 0) {
+          p = visibleStreams_.size();
+        } else {
+          p--;
+        }
+      } else {
+        if (p >= visibleStreams_.size()) {
+          p = 0;
+        } else {
+          p++;
+        }
+      }
+      visibleStreams_.insert(visibleStreams_.begin() + p, id);
+      break;
+    }
+  }
+  relayout();
+}
+
+void FileReader::savePreset(const QString& preset) {
+  layoutPresets_[preset] = configurationAsVariant();
+  layoutConfigChanged();
+}
+
+void FileReader::recallPreset(const QString& preset) {
+  if (layoutPresets_.contains(preset)) {
+    applyConfiguration(layoutPresets_[preset]);
+    sanitizeVisibleStreams();
+    relayout();
+    waitEvent_.dispatchEvent(kReadCurrentFrame);
+  }
+}
+
+void FileReader::deletePreset(const QString& preset) {
+  layoutPresets_.erase(layoutPresets_.find(preset));
+  layoutConfigChanged();
+}
+
+void FileReader::relayout() {
+  if (videoFrames_ != nullptr) {
+    layoutFrames(videoFrames_, playerUi_, lastMaxPerRow_);
+  }
+}
+
+void FileReader::layoutFrames(QVBoxLayout* videoFrames, QWidget* parent, int maxPerRow) {
+  clearLayout(videoFrames, false);
+  maxPerRow = max<int>(maxPerRow, 1);
+  maxPerRow = min<int>(maxPerRow, static_cast<int>(imageReaders_.size()));
+  lastMaxPerRow_ = maxPerRow;
+  QHBoxLayout* innerHlayout = nullptr;
+  int count = 0;
+  for (auto id : visibleStreams_) {
+    if (innerHlayout == nullptr) {
+      innerHlayout = new QHBoxLayout();
+      videoFrames->addLayout(innerHlayout);
+    }
+    innerHlayout->addWidget(imageReaders_[id]->getWidget());
+    if (++count % maxPerRow == 0) {
+      innerHlayout = nullptr;
+    }
+  }
+  layoutConfigChanged();
+}
+
+void FileReader::layoutConfigChanged() {
+  emit updateLayoutMenu(
+      getImageCount(),
+      visibleStreams_.size(),
+      lastMaxPerRow_,
+      layoutPresets_,
+      configurationAsVariant());
+}
+
+void FileReader::restoreCurrentConfig() {
+  QVariant currentConfig = fileConfig_->value(kLastConfiguration);
+  if (!currentConfig.isValid()) {
+    // restore previous settings
+    for (const auto& reader : imageReaders_) {
+      StreamId configId{fileToConfig_[reader.first]};
+      QString name = configId.getNumericName().c_str();
+      reader.second->getWidget()->setRotation(
+          fileConfig_->value(rotationName(name), int(0)).toInt());
+      reader.second->getWidget()->setFlipped(fileConfig_->value(flippedName(name), false).toBool());
+    }
+    lastMaxPerRow_ = fileConfig_->value(kLastMaxPerRow, int(0)).toInt();
+  } else {
+    applyConfiguration(currentConfig);
+  }
+}
+
+void FileReader::saveConfiguration() {
+  if (fileReader_ == nullptr || fileConfig_ == nullptr) {
+    return;
+  }
+  fileConfig_->clear();
+  fileConfig_->setValue(kLastConfiguration, configurationAsVariant());
+  fileConfig_->setValue(kLayoutPresets, layoutPresets_);
+  fileConfig_->sync();
+  //  QJsonDocument configJson(QJsonDocument::fromVariant(fileConfig_->value(kLastConfiguration)));
+  //  QByteArray config = configJson.toJson();
+  //  XR_LOGI("Saved config: {}", string(config.constData(), config.size()));
+}
+
+void FileReader::loadConfiguration() {
+  if (fileReader_ == nullptr) {
+    fileConfig_.reset();
+    return;
+  }
+  fileToConfig_.clear();
+  map<RecordableTypeId, uint16_t> instanceCounters;
+  for (auto id : fileReader_->getStreams()) {
+    uint16_t instance = ++instanceCounters[id.getTypeId()];
+    StreamId configId(id.getTypeId(), instance);
+    fileToConfig_[id] = configId;
+  }
+  stringstream ss;
+  for (const auto& iter : instanceCounters) {
+    ss << StreamId(iter.first, iter.second).getNumericName() << '_';
+  }
+  fileConfig_ = make_unique<QSettings>("VRSplayer", ss.str().c_str());
+  layoutPresets_ = fileConfig_->value(kLayoutPresets).toMap();
+  //  for (auto key : layoutPresets_.keys()) {
+  //    QJsonDocument jdoc = QJsonDocument::fromVariant(layoutPresets_[key]);
+  //    QByteArray config = jdoc.toJson();
+  //    XR_LOGI("\nPreset {}: {}", key.toStdString(), string(config.constData(), config.size()));
+  //  }
+}
+
+static int rawTimeToPosition(double time) {
+  return static_cast<int>(time * 10000);
+}
+
+static double rawPositionToTime(int position) {
+  return static_cast<double>(position) / 10000;
+}
+
+int FileReader::timeToPosition(double time) const {
+  if (endTime_ <= startTime_ || time <= startTime_) {
+    return 0;
+  }
+  if (time >= endTime_) {
+    return rawTimeToPosition(endTime_ - startTime_);
+  }
+  return rawTimeToPosition(time - startTime_);
+}
+
+double FileReader::positionToTime(int position) const {
+  return endTime_ <= startTime_ ? startTime_ : startTime_ + rawPositionToTime(position);
+}
+
+void FileReader::setState(FileReaderState newState) {
+  if (newState == FileReaderState::Playing && fileReader_ == nullptr) {
+    return; // no file: deny state change request!
+  }
+  {
+    unique_lock<recursive_mutex> guard{mutex_};
+    state_ = newState;
+    if (state_ == FileReaderState::Playing) {
+      fileReader_->setCachingStrategy(CachingStrategy::Streaming);
+      setBlankMode(false);
+      const auto& index = fileReader_->getIndex();
+      if (nextRecord_ < index.size()) {
+        time_.setTime(index[nextRecord_].timestamp);
+      }
+      time_.start();
+      waitEvent_.dispatchEvent();
+    } else {
+      time_.pause();
+    }
+  }
+  cout << "Video state: " << FileReaderStateConverter::toString(newState) << endl;
+  mediaStateChanged(state_);
+}
+
+void FileReader::setTimeRange(double start, double end, uint32_t firstDataRecordIndex) {
+  startTime_ = start;
+  endTime_ = end;
+  firstDataRecordIndex_ = firstDataRecordIndex;
+  cout << "Start: " << helpers::humanReadableTimestamp(start)
+       << ", end: " << helpers::humanReadableTimestamp(end) << endl;
+  durationChanged(start, end, rawTimeToPosition(endTime_ - startTime_));
+}
+
+} // namespace vrsp

--- a/tools/vrsplayer/FileReader.h
+++ b/tools/vrsplayer/FileReader.h
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <QtCore/qglobal.h>
+#include <qobject.h>
+#include <qsettings.h>
+#include <qtimer.h>
+
+#include <vrs/RecordFileReader.h>
+#include <vrs/RecordFormatStreamPlayer.h>
+#include <vrs/os/Event.h>
+
+#include "AudioPlayer.h"
+#include "FramePlayer.h"
+#include "FrameWidget.h"
+#include "VideoTime.h"
+
+QT_BEGIN_NAMESPACE
+class QPixmap;
+class QVBoxLayout;
+QT_END_NAMESPACE
+
+enum class FileReaderState { Undefined, NoMedia, Paused, Playing, Error, Count };
+Q_DECLARE_METATYPE(FileReaderState)
+
+namespace vrsp {
+
+using ::vrs::ProgressLogger;
+using ::vrs::RecordFileReader;
+
+using vrs::os::EventChannel;
+
+class PlayerUI;
+
+enum class Action { ShowFrame = 1, ShowFrameFast, ChangeFrame };
+enum class Direction { Forward, Backward };
+enum class Seek { Accurate, Fast };
+
+// Helper class to bundle an enum + frameCount as int64_t, for use in an event
+struct DispatchAction {
+  explicit DispatchAction(Action _action) : action{_action}, frameCount{0} {}
+  explicit DispatchAction(Action _action, int32_t _frameCount)
+      : action{_action}, frameCount{_frameCount} {}
+
+  int64_t bundle() const {
+    return static_cast<int64_t>(frameCount) << 32 | static_cast<int64_t>(action);
+  }
+  static DispatchAction fromBundle(int64_t bundle) {
+    return DispatchAction(
+        static_cast<Action>(bundle & 0xffffffff),
+        static_cast<int32_t>((bundle >> 32) & 0xffffffff));
+  }
+
+  Action action;
+  int32_t frameCount;
+};
+
+class FileReader : public QObject {
+  Q_OBJECT
+
+ public:
+  static constexpr double kMaxPlaybackAge = 0.2;
+
+  explicit FileReader(QObject* parent = nullptr);
+  ~FileReader();
+
+  void setPlayerUi(PlayerUI* ui) {
+    playerUi_ = ui;
+  }
+  FileReaderState getState() const {
+    return state_;
+  }
+  bool isAtBegin() const;
+  bool isAtEnd() const;
+  bool isLocalFile() const {
+    return isLocalFile_;
+  }
+  int getImageCount() const {
+    return static_cast<int>(imageReaders_.size());
+  }
+  void layoutFrames(QVBoxLayout* videoFrames, QWidget* parent, int maxPerRow);
+  void saveConfiguration();
+  void loadConfiguration();
+
+ signals:
+  void mediaStateChanged(FileReaderState state);
+  void durationChanged(double start, double end, int duration);
+  void timeChanged(double time, int position);
+  void statusStateChanged(const std::string& status);
+  void adjustSpeed(int change);
+  void updateLayoutMenu(
+      int frameCount,
+      int visibleCount,
+      int maxPerRowCount,
+      const QVariantMap& presets,
+      const QVariant& currentPreset);
+  void fileChanged(QWidget* widget, const vrs::FileSpec& spec);
+
+ public slots:
+  std::vector<FrameWidget*> openFile(const QString& url, QVBoxLayout* videoFrame, QWidget* parent);
+  void setOverlayColor(QColor color);
+  void recordTypeChanged(const QString& type);
+  void setPosition(int position);
+  void sliderPressed();
+  void sliderReleased();
+  bool eventFilter(QObject* obj, QEvent* event);
+  void stop();
+  void play();
+  void pause();
+  void nextFrame();
+  void previousFrame();
+  void updatePosition();
+  void relayout();
+  void setPlaybackSpeed(double speed);
+  void enableAllStreams();
+  void toggleVisibleStreams();
+  void resetOrientation();
+  void disableStream(StreamId id);
+  void moveStream(StreamId id, bool beforeNotAfter);
+  void savePreset(const QString& preset);
+  void recallPreset(const QString& preset);
+  void deletePreset(const QString& preset);
+
+ private:
+  int timeToPosition(double time) const;
+  double positionToTime(int position) const;
+  void setState(FileReaderState newState);
+  void setTimeRange(double start, double end, uint32_t firstDataRecordIndex);
+  void playThreadActivity();
+  void playAction(DispatchAction action);
+  bool playFrameSet(const std::set<size_t>& frameSet, Seek strategy);
+  bool getFrameSet(std::set<size_t>& outSet, size_t start, Direction direction) const;
+  double getNextRecordDelay();
+  void setBlankMode(bool setBlankMode);
+  void clearLayout(QLayout* layout, bool deleteWidgets);
+  void readFirstRecord(StreamId id, Record::Type recordType);
+  void setErrorText(const std::string& errorText);
+  bool isAudio(StreamId id) const;
+  bool isVideo(StreamId id) const;
+  bool isPlaying(StreamId id) const {
+    return isAudio(id) || isVisibleVideo(id);
+  }
+  bool isVisibleVideo(StreamId id) const;
+  std::string getDeviceName(StreamId id);
+  void sanitizeVisibleStreams(bool reset = false);
+  QVariant configurationAsVariant();
+  void applyConfiguration(const QVariant& config);
+  void layoutConfigChanged();
+  void restoreCurrentConfig();
+  int readRecordIfNeeded(const vrs::IndexRecord::RecordInfo& record, size_t recordIndex, bool log);
+
+  std::vector<FrameWidget*> openFile(QVBoxLayout* videoFrames, QWidget* parent);
+  void closeFile();
+
+ private:
+  PlayerUI* playerUi_;
+  std::vector<StreamId> visibleStreams_;
+  QVBoxLayout* videoFrames_{};
+  int lastMaxPerRow_{0};
+  std::map<StreamId, std::unique_ptr<FramePlayer>> imageReaders_;
+  std::map<StreamId, std::unique_ptr<AudioPlayer>> audioReaders_;
+  std::map<StreamId, size_t> lastReadRecords_;
+  Record::Type recordType_{Record::Type::UNDEFINED};
+  QTimer slowTimer_;
+  FileReaderState state_;
+  std::unique_ptr<RecordFileReader> fileReader_;
+  bool isLocalFile_;
+  bool isSliderActive_;
+  bool layoutUpdatesEnabled_{true};
+  double startTime_;
+  double endTime_;
+  uint32_t firstDataRecordIndex_;
+  double lastShownTime_;
+  size_t nextRecord_;
+  VideoTime time_;
+  bool runThread_{true};
+  EventChannel waitEvent_{"video_wait", EventChannel::NotificationMode::UNICAST};
+  std::recursive_mutex mutex_;
+  std::thread thread_;
+
+  // File specific configuration
+  std::unique_ptr<QSettings> fileConfig_;
+  std::map<StreamId, StreamId> fileToConfig_;
+  QVariantMap layoutPresets_;
+};
+
+} // namespace vrsp

--- a/tools/vrsplayer/FramePlayer.cpp
+++ b/tools/vrsplayer/FramePlayer.cpp
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "FramePlayer.h"
+
+#include <sstream>
+
+#include <fmt/format.h>
+
+namespace vrsp {
+
+using namespace std;
+
+FramePlayer::FramePlayer(StreamId id, FrameWidget* widget)
+    : QObject(nullptr), id_{id}, widget_{widget} {}
+
+bool FramePlayer::processRecordHeader(
+    const CurrentRecord& record,
+    vrs::DataReference& outDataReference) {
+  return visible_ ? VideoRecordFormatStreamPlayer::processRecordHeader(record, outDataReference)
+                  : false;
+}
+
+bool FramePlayer::onDataLayoutRead(
+    const CurrentRecord& record,
+    size_t blockIndex,
+    DataLayout& layout) {
+  ostringstream buffer;
+  layout.printLayoutCompact(buffer);
+  string text = buffer.str();
+  descriptions_.setDescription(record.recordType, blockIndex, text);
+  widget_->setDescription(record.recordType, blockIndex, text);
+  if (firstImage_ && record.recordType == Record::Type::CONFIGURATION) {
+    vrs::DataPieceString* deviceType = layout.findDataPieceString("device_type");
+    if (deviceType != nullptr) {
+      widget_->setDeviceType(deviceType->get());
+    }
+  }
+  return true; // read next blocks, if any
+}
+
+bool FramePlayer::onImageRead(
+    const CurrentRecord& record,
+    size_t /*blockIndex*/,
+    const ContentBlock& contentBlock) {
+  widget_->setDataFps(dataFps_.newFrame()); // fps counter for images read from file
+  const auto& spec = contentBlock.image();
+  shared_ptr<PixelFrame> frame = getFrame(true);
+  bool frameValid = false;
+  unique_ptr<ImageJob> job;
+  switch (spec.getImageFormat()) {
+    case vrs::ImageFormat::RAW:
+      // RAW images are read from disk directly, but pixel format conversion is asynchronous
+      frameValid = PixelFrame::readRawFrame(frame, record.reader, spec);
+      if (!firstImage_ && frameValid) {
+        job = make_unique<ImageJob>(vrs::ImageFormat::RAW);
+      }
+      break;
+    case vrs::ImageFormat::JPG:
+      if (firstImage_) {
+        frameValid = PixelFrame::readJpegFrame(frame, record.reader, contentBlock.getBlockSize());
+      } else {
+        // JPG decoding & pixel format conversion happen asynchronously
+        job = make_unique<ImageJob>(vrs::ImageFormat::JPG);
+        job->buffer.resize(contentBlock.getBlockSize());
+        frameValid = (record.reader->read(job->buffer) == 0);
+      }
+      break;
+    case vrs::ImageFormat::PNG:
+      if (firstImage_) {
+        frameValid = PixelFrame::readPngFrame(frame, record.reader, contentBlock.getBlockSize());
+      } else {
+        // PNG decoding & pixel format conversion happen asynchronously
+        job = make_unique<ImageJob>(vrs::ImageFormat::PNG);
+        job->buffer.resize(contentBlock.getBlockSize());
+        frameValid = (record.reader->read(job->buffer) == 0);
+      }
+      break;
+    case vrs::ImageFormat::VIDEO:
+      // Video codec decompression happens here, but pixel format conversion is asynchronous
+      PixelFrame::init(frame, contentBlock.image());
+      frameValid = (tryToDecodeFrame(*frame, record, contentBlock) == 0);
+      if (!firstImage_ && frameValid) {
+        job = make_unique<ImageJob>(vrs::ImageFormat::VIDEO);
+      }
+      break;
+    default:
+      frameValid = false;
+      break;
+  }
+  if (frameValid && job) {
+    job->frame = move(frame);
+    imageJobs_.startThreadIfNeeded(&FramePlayer::imageJobsThreadActivity, this);
+    imageJobs_.sendJob(move(job));
+    return true;
+  }
+  if (firstImage_) {
+    fmt::print(
+        "Found '{} - {}': {}, {}",
+        record.streamId.getNumericName(),
+        record.streamId.getTypeName(),
+        getCurrentRecordFormatReader()->recordFormat.asString(),
+        spec.asString());
+    blankMode_ = false;
+  }
+  if (frameValid) {
+    convertFrame(frame);
+    if (firstImage_) {
+      if (!frame->hasSamePixels(spec)) {
+        fmt::print(" -> {}", frame->getSpec().asString());
+      }
+      frame->blankFrame();
+      blankMode_ = true;
+    }
+    widget_->swapImage(frame);
+  }
+  recycle(frame, !needsConvertedFrame_);
+  if (firstImage_) {
+    fmt::print("\n");
+    firstImage_ = false;
+  }
+  return true; // read next blocks, if any
+}
+
+void FramePlayer::setVisible(bool visible) {
+  visible_ = visible;
+  widget_->setVisible(visible_);
+}
+
+void FramePlayer::convertFrame(shared_ptr<PixelFrame>& frame) {
+  if (blankMode_) {
+    makeBlankFrame(frame);
+  } else {
+    shared_ptr<PixelFrame> convertedFrame = needsConvertedFrame_ ? getFrame(false) : nullptr;
+    PixelFrame::normalizeFrame(frame, convertedFrame, false);
+    needsConvertedFrame_ = (frame != convertedFrame); // for next time!
+    if (needsConvertedFrame_) {
+      recycle(frame, true);
+      frame = move(convertedFrame);
+    }
+  }
+}
+
+void FramePlayer::makeBlankFrame(shared_ptr<PixelFrame>& frame) {
+  frame->init(vrs::PixelFormat::GREY8, frame->getWidth(), frame->getHeight());
+  frame->blankFrame();
+}
+
+shared_ptr<PixelFrame> FramePlayer::getFrame(bool inputNotConvertedFrame) {
+  unique_lock lock(frameMutex_);
+  vector<shared_ptr<PixelFrame>>& frames = inputNotConvertedFrame ? inputFrames_ : convertedframes_;
+  if (frames.empty()) {
+    return nullptr;
+  }
+  shared_ptr<PixelFrame> frame = move(frames.back());
+  frames.pop_back();
+  return frame;
+}
+
+void FramePlayer::recycle(shared_ptr<PixelFrame>& frame, bool inputNotConvertedFrame) {
+  if (frame) {
+    {
+      unique_lock lock(frameMutex_);
+      vector<shared_ptr<PixelFrame>>& frames =
+          inputNotConvertedFrame ? inputFrames_ : convertedframes_;
+      if (frames.size() < 10) {
+        frames.emplace_back(move(frame));
+      }
+    }
+    frame.reset();
+  }
+}
+
+void FramePlayer::setBlankMode(bool blankOn) {
+  if (blankMode_ != blankOn) {
+    blankMode_ = blankOn;
+    if (blankMode_) {
+      widget_->blank();
+    } else {
+      // Descriptions are lost when we blank the widget, so we need to restore them, but we don't
+      // need to restore DATA record descriptions, as they're present with every data record.
+      widget_->setDescriptions(
+          Record::Type::CONFIGURATION, descriptions_.getDescriptions(Record::Type::CONFIGURATION));
+      widget_->setDescriptions(
+          Record::Type::STATE, descriptions_.getDescriptions(Record::Type::STATE));
+    }
+  }
+}
+
+void FramePlayer::mediaStateChanged(FileReaderState state) {
+  if (state != state_) {
+    dataFps_.reset();
+    state_ = state;
+  }
+}
+
+void FramePlayer::imageJobsThreadActivity() {
+  unique_ptr<ImageJob> job;
+  while (imageJobs_.waitForJob(job)) {
+    shared_ptr<PixelFrame> frame = move(job->frame);
+    // if we're behind, we just drop images except the last one!
+    while (imageJobs_.getJob(job)) {
+      recycle(frame, true);
+      frame = move(job->frame);
+    }
+    bool frameValid = false;
+    switch (job->imageFormat) {
+      case vrs::ImageFormat::RAW:
+      case vrs::ImageFormat::VIDEO:
+        frameValid = (frame != nullptr);
+        break;
+      case vrs::ImageFormat::JPG:
+      case vrs::ImageFormat::PNG: {
+        if (!frame) {
+          frame = make_shared<PixelFrame>();
+        }
+        if (job->imageFormat == vrs::ImageFormat::JPG) {
+          frameValid = frame->readJpegFrame(job->buffer);
+        } else {
+          frameValid = frame->readPngFrame(job->buffer);
+        }
+      } break;
+      default:
+        break;
+    }
+    if (frameValid) {
+      convertFrame(frame);
+      widget_->swapImage(frame);
+    }
+    recycle(frame, !frameValid || !needsConvertedFrame_);
+  }
+}
+
+} // namespace vrsp

--- a/tools/vrsplayer/FramePlayer.h
+++ b/tools/vrsplayer/FramePlayer.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include <QtCore/qglobal.h>
+#include <qobject.h>
+
+#include <vrs/RecordFormat.h>
+#include <vrs/helpers/JobQueue.h>
+#include <vrs/utils/PixelFrame.h>
+#include <vrs/utils/VideoFrameHandler.h>
+#include <vrs/utils/VideoRecordFormatStreamPlayer.h>
+
+#include "FrameWidget.h"
+#include "MetaDataCollector.h"
+
+QT_BEGIN_NAMESPACE
+class QPixmap;
+QT_END_NAMESPACE
+
+enum class FileReaderState;
+
+namespace vrsp {
+
+using ::std::shared_ptr;
+using ::std::unique_ptr;
+using ::std::vector;
+using ::vrs::ContentBlock;
+using ::vrs::CurrentRecord;
+using ::vrs::DataLayout;
+using ::vrs::StreamId;
+using ::vrs::StreamPlayer;
+using ::vrs::utils::PixelFrame;
+using ::vrs::utils::VideoRecordFormatStreamPlayer;
+
+struct ImageJob {
+  ImageJob(vrs::ImageFormat imageFormat) : imageFormat{imageFormat} {}
+  vrs::ImageFormat imageFormat;
+  shared_ptr<PixelFrame> frame;
+  vector<uint8_t> buffer;
+};
+
+class FramePlayer : public QObject, public VideoRecordFormatStreamPlayer {
+  Q_OBJECT
+ public:
+  explicit FramePlayer(StreamId id, FrameWidget* widget_);
+
+  bool processRecordHeader(const CurrentRecord& r, vrs::DataReference& outDataReference) override;
+  bool onDataLayoutRead(const CurrentRecord& r, size_t blockIndex, DataLayout&) override;
+  bool onImageRead(const CurrentRecord& r, size_t blockIndex, const ContentBlock&) override;
+
+  StreamId getId() const {
+    return id_;
+  }
+  FrameWidget* getWidget() const {
+    return widget_;
+  }
+
+  void setVisible(bool visible);
+  bool isVisible() const {
+    return visible_;
+  }
+  void setBlankMode(bool blankOn);
+
+  void imageJobsThreadActivity();
+
+ public slots:
+  void mediaStateChanged(FileReaderState state);
+
+ private:
+  std::mutex frameMutex_;
+  vector<shared_ptr<PixelFrame>> inputFrames_;
+  vector<shared_ptr<PixelFrame>> convertedframes_;
+  bool needsConvertedFrame_{};
+  StreamId id_;
+  FrameWidget* widget_;
+  MetaDataCollector descriptions_;
+  bool visible_{true};
+  bool blankMode_{true};
+  bool firstImage_{true};
+  Fps dataFps_;
+  FileReaderState state_{};
+
+  vrs::JobQueueWithThread<std::unique_ptr<ImageJob>> imageJobs_;
+
+  void convertFrame(shared_ptr<PixelFrame>& frame);
+  void makeBlankFrame(shared_ptr<PixelFrame>& frame);
+  shared_ptr<PixelFrame> getFrame(bool inputNotConvertedFrame);
+  void recycle(shared_ptr<PixelFrame>& frame, bool inputNotConvertedFrame);
+};
+
+} // namespace vrsp

--- a/tools/vrsplayer/FrameWidget.cpp
+++ b/tools/vrsplayer/FrameWidget.cpp
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "FrameWidget.h"
+
+#include <sstream>
+
+#include <qapplication.h>
+#include <qdesktopwidget.h>
+#include <qimage.h>
+#include <qmenu.h>
+#include <qpainter.h>
+#include <qsizepolicy.h>
+
+#define DEFAULT_LOG_CHANNEL "FrameWidget"
+#include <logging/Log.h>
+#include <vrs/TagConventions.h>
+#include <vrs/utils/PixelFrame.h>
+
+using namespace vrs;
+using namespace std;
+
+namespace {
+bool convertToQImageFormat(const vrs::PixelFormat format, QImage::Format& formatOut) {
+  switch (format) {
+    case vrs::PixelFormat::GREY8:
+      formatOut = QImage::Format_Grayscale8;
+      break;
+    case vrs::PixelFormat::RGB8:
+      formatOut = QImage::Format_RGB888;
+      break;
+    case vrs::PixelFormat::RGBA8:
+      formatOut = QImage::Format_RGBA8888;
+      break;
+    default:
+      formatOut = QImage::Format_Grayscale8;
+      return false;
+  }
+  return true;
+}
+} // namespace
+
+namespace vrsp {
+
+FrameWidget::FrameWidget(QWidget* parent) {
+  setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
+  setContextMenuPolicy(Qt::CustomContextMenu);
+  connect(this, &FrameWidget::customContextMenuRequested, this, &FrameWidget::ShowContextMenu);
+}
+
+void FrameWidget::paintEvent(QPaintEvent* evt) {
+  QPainter painter(this);
+  painter.setRenderHint(QPainter::Antialiasing);
+  const QRect wrect = painter.window();
+  const QRect rect = painter.viewport();
+  int hOffset = 0;
+  int vOffset = 0;
+  painter.setPen(overlayColor_);
+  bool hasImage = false;
+  { // mutex scoope
+    unique_lock lock(mutex_);
+    PixelFrame* image = image_.get();
+    if (image != nullptr) {
+      QImage::Format qformat;
+      hasImage = convertToQImageFormat(image->getPixelFormat(), qformat);
+      if (hasImage) {
+        QSize size = image->qsize();
+        QImage qImage(
+            image->rdata(),
+            size.width(),
+            size.height(),
+            static_cast<int>(image->getStride()),
+            qformat);
+        painter.translate(rect.width() / 2, rect.height() / 2);
+        QSize rsize = size;
+        rsize.scale(rotate(rect.size()), Qt::KeepAspectRatio);
+        bool sideWays = rotation_ % 180 != 0;
+        painter.scale(
+            ((flipped_ && !sideWays) ? -1. : 1.) * rsize.width() / size.width(),
+            ((flipped_ && sideWays) ? -1. : 1.) * rsize.height() / size.height());
+        painter.rotate(rotation_);
+        painter.drawImage(-size.width() / 2, -size.height() / 2, qImage);
+        rsize = rotate(rsize);
+        hOffset = (rect.width() - rsize.width()) / 2;
+        vOffset = (rect.height() - rsize.height()) / 2;
+
+        // undo scaling
+        painter.setViewport(rect);
+        painter.setWindow(wrect);
+        painter.resetTransform();
+      } else {
+        XR_LOGW(
+            "Could not convert pixel format {} to a Qt equivalent. "
+            "Falling back to Grayscale8, but you'll probably see nothing.",
+            vrs::toString(image->getPixelFormat()));
+
+        if (painter.font().pointSize() != 16) {
+          QFont font = painter.font();
+          font.setPointSize(16);
+          painter.setFont(font);
+        }
+        painter.setPen(Qt::black);
+        QString description =
+            QString::fromStdString(vrs::toString(image->getPixelFormat()).c_str()) +
+            " pixel format not supported...";
+        painter.drawText(QPointF(rect.left() + 4, rect.bottom() - 4), description);
+      }
+    }
+  } // mutex scoope
+
+  // draw description overlay
+  if (painter.font().pointSize() != 14) {
+    QFont font = painter.font();
+    font.setPointSize(14);
+    painter.setFont(font);
+  }
+  QString description = descriptions_.getDescription(typeToShow_);
+  painter.drawText(rect.adjusted(hOffset, vOffset + 4, 2, 2), Qt::AlignLeft, description);
+
+  // draw fps overlay
+  if (hasImage && dataFps_ > 0) {
+    QString fpsStr = QString("%1/%2").arg(dataFps_).arg(imageFps_.value());
+    int fps = drawFps_.newFrame();
+    if (fps > 0) {
+      fpsStr += QString("-%1").arg(fps);
+    }
+    fpsStr += " fps";
+    QRect r(rect.left() + hOffset + 4, rect.top(), rect.width(), rect.height() - vOffset - 4);
+    painter.drawText(r, Qt::AlignLeft | Qt::AlignBottom, fpsStr);
+  }
+}
+
+QSize FrameWidget::sizeHint() const {
+  return getImageSize().scaled(QSize(500, 500), Qt::KeepAspectRatio);
+}
+
+int FrameWidget::heightForWidth(int w) const {
+  QSize size = getImageSize();
+  return (w * size.height()) / size.width();
+}
+
+void FrameWidget::swapImage(shared_ptr<PixelFrame>& image) {
+  unique_lock lock(mutex_);
+  imageFps_.newFrame();
+  bool resize = image && image->qsize() != imageSize_;
+  image_.swap(image);
+  if (resize) {
+    imageSize_ = image_->qsize();
+    updateMinMaxSize();
+  }
+  setNeedsUpdate();
+}
+
+void FrameWidget::updateMinMaxSize() {
+  if (image_) {
+    QSize size = getImageSize();
+    setMinimumSize(size.scaled(100, 100, Qt::KeepAspectRatio));
+    setBaseSize(size);
+    QSize screen = QApplication::desktop()->screenGeometry(this).size().operator*=(0.95);
+    setMaximumSize(size.scaled(screen, Qt::KeepAspectRatio));
+  }
+}
+
+void FrameWidget::ShowContextMenu(const QPoint& pos) {
+  QMenu contextMenu(tr("Context menu"), this);
+  QAction noRotation("No Rotation", this);
+  connect(&noRotation, &QAction::triggered, [this]() { this->setRotation(0); });
+  noRotation.setCheckable(true);
+  noRotation.setChecked(rotation_ == 0);
+  contextMenu.addAction(&noRotation);
+  QAction rotate90("Rotate Right", this);
+  connect(&rotate90, &QAction::triggered, [this]() { this->setRotation(90); });
+  rotate90.setCheckable(true);
+  rotate90.setChecked(rotation_ == 90);
+  contextMenu.addAction(&rotate90);
+  QAction rotate180("Rotate Upside-Down", this);
+  connect(&rotate180, &QAction::triggered, [this]() { this->setRotation(180); });
+  rotate180.setCheckable(true);
+  rotate180.setChecked(rotation_ == 180);
+  contextMenu.addAction(&rotate180);
+  QAction rotate270("Rotate Left", this);
+  connect(&rotate270, &QAction::triggered, [this]() { this->setRotation(270); });
+  rotate270.setCheckable(true);
+  rotate270.setChecked(rotation_ == 270);
+  contextMenu.addAction(&rotate270);
+
+  contextMenu.addSeparator();
+  QAction mirror("Mirror Image", this);
+  connect(&mirror, &QAction::triggered, [this]() { this->setFlipped(!flipped_); });
+  mirror.setCheckable(true);
+  mirror.setChecked(flipped_);
+  contextMenu.addAction(&mirror);
+
+  contextMenu.addSeparator();
+  QAction before("Move Before", this);
+  connect(&before, &QAction::triggered, [this]() { emit this->shouldMoveBefore(); });
+  contextMenu.addAction(&before);
+  QAction after("Move After", this);
+  connect(&after, &QAction::triggered, [this]() { emit this->shouldMoveAfter(); });
+  contextMenu.addAction(&after);
+  QAction hide("Hide Stream", this);
+  connect(&hide, &QAction::triggered, [this]() { emit this->shouldHideStream(); });
+  contextMenu.addAction(&hide);
+
+  contextMenu.exec(mapToGlobal(pos));
+}
+
+void FrameWidget::blank() {
+  {
+    unique_lock lock(mutex_);
+    if (image_) {
+      image_->blankFrame();
+    }
+  }
+  descriptions_.clearDescription();
+  dataFps_ = 0;
+  imageFps_.reset();
+  drawFps_.reset();
+  setNeedsUpdate();
+}
+
+void FrameWidget::setDeviceName(const string& deviceName) {
+  vector<string> tooltip;
+  if (!deviceName.empty()) {
+    tooltip.emplace_back(deviceName);
+  }
+  if (!deviceTypeTag_.empty() &&
+      (deviceTypeConfig_.empty() || deviceTypeConfig_ != deviceTypeTag_)) {
+    const char* label = !deviceTypeConfig_.empty() ? "Device type tag: " : "Device type: ";
+    tooltip.emplace_back(label + deviceTypeTag_);
+  }
+  if (!deviceTypeConfig_.empty()) {
+    tooltip.emplace_back("Device type: " + deviceTypeConfig_);
+  }
+  auto tooltipStr = fmt::format("{}", fmt::join(tooltip, "\n"));
+  setToolTip(QString::fromUtf8(tooltipStr.c_str()));
+}
+
+void FrameWidget::setDeviceType(const string& deviceType) {
+  deviceTypeConfig_ = deviceType;
+}
+
+void FrameWidget::setDescription(
+    Record::Type recordType,
+    size_t blockIndex,
+    const string& description) {
+  descriptions_.setDescription(recordType, blockIndex, description);
+}
+
+void FrameWidget::setDescriptions(
+    Record::Type recordType,
+    const map<size_t, QString>& descriptions) {
+  descriptions_.setDescriptions(recordType, descriptions);
+}
+
+void FrameWidget::setTags(const map<string, string>& tags) {
+  stringstream ss;
+  for (const auto& tag : tags) {
+    if (tag.first == vrs::tag_conventions::kDeviceType) {
+      deviceTypeTag_ = tag.second;
+    }
+    ss << "  " << tag.first << ": " << tag.second << "\n";
+  }
+  descriptions_.setDescription(Record::Type::TAGS, 0, ss.str());
+}
+
+void FrameWidget::resetOrientation() {
+  rotation_ = 0;
+  flipped_ = false;
+  setNeedsUpdate();
+  emit orientationChanged();
+}
+
+void FrameWidget::setRotation(int rotation) {
+  rotation_ = rotation;
+  updateMinMaxSize();
+  setNeedsUpdate();
+  emit orientationChanged();
+}
+
+void FrameWidget::setFlipped(bool flipped) {
+  flipped_ = flipped;
+  setNeedsUpdate();
+}
+
+QSize FrameWidget::rotate(QSize size) const {
+  return (rotation_ % 180) == 0 ? size : size.transposed();
+}
+
+QSize FrameWidget::getImageSize() const {
+  return rotate(imageSize_);
+}
+
+} // namespace vrsp

--- a/tools/vrsplayer/FrameWidget.h
+++ b/tools/vrsplayer/FrameWidget.h
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <deque>
+#include <map>
+#include <memory>
+#include <mutex>
+
+#include <QtCore/qglobal.h>
+#include <QtWidgets/QWidget>
+
+#include <vrs/Record.h>
+
+#include "MetaDataCollector.h"
+#include "VideoTime.h"
+
+namespace vrs::utils {
+class PixelFrame;
+}
+
+namespace vrsp {
+
+using std::map;
+using std::shared_ptr;
+using std::string;
+using vrs::utils::PixelFrame;
+
+// Frame Per Second estimator class
+class Fps {
+ public:
+  void reset() {
+    lastTimestamps_.clear();
+  }
+  // Call when there is a new frame, and get an updated fps estimation
+  int newFrame() {
+    double time = VideoTime::getRawTime();
+    // When switching to PortAudio, during init the time source might change.
+    if (!lastTimestamps_.empty() && lastTimestamps_.back() >= time) {
+      lastTimestamps_.clear();
+    }
+    lastTimestamps_.push_back(time);
+    return value(time);
+  }
+  int value(double time = VideoTime::getRawTime()) {
+    double timeLimit = time - 1.5; // only keep recent data
+    while (!lastTimestamps_.empty() && lastTimestamps_.front() < timeLimit) {
+      lastTimestamps_.pop_front();
+    }
+    size_t count = lastTimestamps_.size();
+    if (count < 2) {
+      return 0;
+    }
+    return static_cast<int>(
+        (count - 1) / static_cast<float>(lastTimestamps_.back() - lastTimestamps_.front()) + 0.5F);
+  }
+
+ private:
+  std::deque<double> lastTimestamps_;
+};
+
+class FrameWidget : public QWidget {
+  Q_OBJECT
+ public:
+  explicit FrameWidget(QWidget* parent = 0);
+
+  void paintEvent(QPaintEvent* evt) override;
+  QSize sizeHint() const override;
+  int heightForWidth(int w) const override;
+  bool hasHeightForWidth() const override {
+    return true;
+  }
+
+  void setNeedsUpdate() {
+    needsUpdate_.store(true);
+  }
+  bool getAndClearNeedsUpdate() {
+    return needsUpdate_.exchange(false);
+  }
+
+  QSize rotate(QSize size) const;
+  QSize getImageSize() const;
+
+  void setDataFps(int dataFps) {
+    dataFps_ = dataFps;
+  }
+  void setDeviceName(const string& deviceName);
+  void setDeviceType(const string& deviceType);
+  void setDescription(Record::Type recordType, size_t blockIndex, const string& description);
+  void setDescriptions(Record::Type recordType, const map<size_t, QString>& descriptions);
+  void setTags(const map<string, string>& tags);
+
+  void resetOrientation();
+  void setRotation(int rotation);
+  int getRotation() const {
+    return rotation_;
+  }
+
+  void setFlipped(bool flipped);
+  bool getFlipped() const {
+    return flipped_;
+  }
+
+  void swapImage(shared_ptr<PixelFrame>& image);
+
+  void setTypeToShow(Record::Type type) {
+    typeToShow_ = type;
+    setNeedsUpdate();
+  }
+  void setOverlayColor(QColor color) {
+    overlayColor_ = color;
+    setNeedsUpdate();
+  }
+  void blank();
+  void updateMinMaxSize();
+
+ signals:
+  void orientationChanged();
+  void shouldHideStream();
+  void shouldMoveBefore();
+  void shouldMoveAfter();
+
+ public slots:
+  void ShowContextMenu(const QPoint& pos);
+
+ private:
+  std::mutex mutex_;
+  shared_ptr<PixelFrame> image_;
+  string deviceTypeTag_;
+  string deviceTypeConfig_;
+  QSize imageSize_{640, 480};
+  MetaDataCollector descriptions_;
+  Record::Type typeToShow_{Record::Type::DATA};
+  std::atomic<bool> needsUpdate_{true};
+  std::atomic<int> dataFps_{0};
+  Fps imageFps_;
+  Fps drawFps_;
+  QColor overlayColor_{Qt::yellow};
+  int rotation_{0};
+  bool flipped_{false};
+};
+
+} // namespace vrsp

--- a/tools/vrsplayer/MetaDataCollector.h
+++ b/tools/vrsplayer/MetaDataCollector.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <mutex>
+
+#include <qstring.h>
+
+#include <vrs/Record.h>
+
+namespace vrsp {
+
+using ::vrs::Record;
+
+class MetaDataCollector {
+ public:
+  void clearDescription() {
+    std::unique_lock<std::mutex> guard(mutex_);
+    descriptions_[Record::Type::CONFIGURATION].clear();
+    descriptions_[Record::Type::STATE].clear();
+    descriptions_[Record::Type::DATA].clear();
+  }
+  void setDescription(Record::Type recordType, size_t blockIndex, const std::string& description) {
+    QString str = QString::fromStdString(description);
+    std::unique_lock<std::mutex> guard(mutex_);
+    descriptions_[recordType][blockIndex] = str;
+  }
+  QString getDescription(Record::Type type) const {
+    QString description;
+    if (!descriptions_.empty()) {
+      std::unique_lock<std::mutex> guard(mutex_);
+      auto descriptions = descriptions_.find(type);
+      if (descriptions != descriptions_.end()) {
+        for (const auto& d : descriptions->second) {
+          description += d.second;
+        }
+      }
+    }
+    return description;
+  }
+  std::map<size_t, QString> getDescriptions(Record::Type recordType) {
+    std::unique_lock<std::mutex> guard(mutex_);
+    return descriptions_[recordType];
+  }
+  void setDescriptions(Record::Type recordType, const std::map<size_t, QString>& descriptions) {
+    std::unique_lock<std::mutex> guard(mutex_);
+    descriptions_[recordType] = descriptions;
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  // Each record type can have multiple metadata blocks
+  std::map<Record::Type, std::map<size_t, QString>> descriptions_;
+};
+
+} // namespace vrsp

--- a/tools/vrsplayer/PlayerUI.cpp
+++ b/tools/vrsplayer/PlayerUI.cpp
@@ -1,0 +1,473 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PlayerUI.h"
+
+#include <cctype>
+
+#include <fmt/format.h>
+
+#include <qmessagebox.h>
+#include <QtWidgets>
+
+#define DEFAULT_LOG_CHANNEL "PlayerUI"
+#include <logging/Verify.h>
+
+#include "VideoTime.h"
+
+#include <vrs/helpers/Strings.h>
+
+namespace vrsp {
+
+using namespace std;
+
+namespace {
+
+const double kDefaultScreenOccupationRatio = 0.8; // use most of the screen (arbitrary)
+
+const QString kLastFilePathSetting("last_file_path");
+const QString kLastRecordTypeSetting("last_record_type");
+const QString kOverlayColorSetting("overlay_color");
+
+const QString kDefaultSpeed("1x");
+
+const vector<QString> kRecordTypeLabels = {
+    "Hide",
+    Record::typeName(Record::Type::TAGS),
+    Record::typeName(Record::Type::CONFIGURATION),
+    Record::typeName(Record::Type::STATE),
+    Record::typeName(Record::Type::DATA),
+};
+
+const vector<pair<QString, double>> kSpeeds = {
+    {"0.125x", 0.125},
+    {"0.25x", 0.25},
+    {"0.50x", 0.50},
+    {"0.75x", 0.75},
+    {kDefaultSpeed, 1.00},
+    {"1.25x", 1.25},
+    {"1.50x", 1.50},
+    {"2.00x", 2.00},
+    {"3.00x", 3.00},
+    {"4.00x", 4.00},
+    {"6.00x", 6.00},
+    {"8.00x", 8.00}};
+
+// Slider that jumps to the position, when you click the slider's bar but not the thumb itself
+class JumpSlider : public QSlider {
+ public:
+  JumpSlider() : QSlider(Qt::Horizontal) {}
+
+ protected:
+  void mousePressEvent(QMouseEvent* event) {
+    QStyleOptionSlider opt;
+    initStyleOption(&opt);
+    QRect sr = style()->subControlRect(QStyle::CC_Slider, &opt, QStyle::SC_SliderHandle, this);
+    if (event->button() == Qt::LeftButton && sr.contains(event->pos()) == false) {
+      int newVal = minimum() + ((maximum() - minimum()) * event->x()) / width();
+      event->accept();
+      sliderMoved(newVal);
+    }
+    QSlider::mousePressEvent(event);
+  }
+};
+
+} // namespace
+
+PlayerUI::PlayerUI(QWidget* parent)
+    : QWidget(parent), time_(nullptr), positionSlider_(nullptr), statusLabel_(nullptr) {
+  fileReader_.setPlayerUi(this);
+  VideoTime::setPlayerUI(this);
+  QAbstractButton* openPathButton = new QPushButton(tr("Open..."));
+  connect(openPathButton, &QAbstractButton::clicked, this, &PlayerUI::openPathChooser);
+  QAbstractButton* openButton = new QPushButton(tr("Select..."));
+  connect(openButton, &QAbstractButton::clicked, this, &PlayerUI::openFileChooser);
+
+  backwardButton_ = new QPushButton;
+  backwardButton_->setEnabled(false);
+  backwardButton_->setIcon(style()->standardIcon(QStyle::SP_MediaSkipBackward));
+  connect(backwardButton_, &QAbstractButton::clicked, this, &PlayerUI::backwardPressed);
+
+  playPauseButton_ = new QPushButton;
+  playPauseButton_->setEnabled(false);
+  playPauseButton_->setIcon(style()->standardIcon(QStyle::SP_MediaPlay));
+  connect(playPauseButton_, &QAbstractButton::clicked, this, &PlayerUI::playPausePressed);
+
+  stopButton_ = new QPushButton;
+  stopButton_->setEnabled(false);
+  stopButton_->setIcon(style()->standardIcon(QStyle::SP_MediaStop));
+  connect(stopButton_, &QAbstractButton::clicked, this, &PlayerUI::stopPressed);
+
+  forwardButton_ = new QPushButton;
+  forwardButton_->setEnabled(false);
+  forwardButton_->setIcon(style()->standardIcon(QStyle::SP_MediaSkipForward));
+  connect(forwardButton_, &QAbstractButton::clicked, this, &PlayerUI::forwardPressed);
+
+  time_ = new QLabel;
+  time_->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
+  time_->setText("0.000");
+  time_->setMinimumWidth(80);
+
+  positionSlider_ = new JumpSlider();
+  positionSlider_->setRange(0, 0);
+  connect(
+      positionSlider_, &QAbstractSlider::sliderPressed, &fileReader_, &FileReader::sliderPressed);
+  connect(positionSlider_, &QAbstractSlider::sliderMoved, &fileReader_, &FileReader::setPosition);
+  connect(
+      positionSlider_, &QAbstractSlider::sliderReleased, &fileReader_, &FileReader::sliderReleased);
+
+  statusLabel_ = new QLabel;
+  statusLabel_->setWordWrap(true);
+  statusLabel_->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
+
+  videoFrames_ = new QVBoxLayout;
+
+  QComboBox* overlayControl = new QComboBox;
+  for (const auto& recordType : kRecordTypeLabels) {
+    overlayControl->addItem(recordType);
+  }
+
+  speedControl_ = new QComboBox;
+  for (const auto& speed : kSpeeds) {
+    speedControl_->addItem(speed.first);
+  }
+
+  QBoxLayout* controlLayout = new QHBoxLayout;
+  controlLayout->addWidget(overlayControl);
+  controlLayout->addStretch();
+
+  controlLayout->addWidget(speedControl_);
+  controlLayout->addWidget(backwardButton_);
+  controlLayout->addWidget(stopButton_);
+  controlLayout->addWidget(playPauseButton_);
+  controlLayout->addWidget(forwardButton_);
+  controlLayout->addWidget(time_);
+
+  controlLayout->addWidget(openPathButton);
+  controlLayout->addWidget(openButton);
+
+  QBoxLayout* layout = new QVBoxLayout;
+  layout->addStretch();
+  layout->addLayout(videoFrames_);
+  layout->addLayout(controlLayout);
+  layout->addWidget(positionSlider_);
+  layout->addWidget(statusLabel_);
+  layout->addStretch();
+
+  setLayout(layout);
+
+  connect(&fileReader_, &FileReader::mediaStateChanged, this, &PlayerUI::mediaStateChanged);
+  connect(&fileReader_, &FileReader::timeChanged, this, &PlayerUI::timeChanged);
+  connect(&fileReader_, &FileReader::durationChanged, this, &PlayerUI::durationChanged);
+  connect(&fileReader_, &FileReader::statusStateChanged, this, &PlayerUI::setStatusText);
+  connect(
+      overlayControl,
+      static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+      [this](int index) { this->recordTypeChanged(index); });
+  connect(
+      speedControl_,
+      static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+      [this](int index) { this->speedControlChanged(index); });
+  connect(&fileReader_, &FileReader::adjustSpeed, this, &PlayerUI::adjustSpeed);
+
+  setFocusPolicy(Qt::StrongFocus);
+
+  // Restore the last selected record type (default: none);
+  QVariant lastRecordType =
+      settings_.value(kLastRecordTypeSetting, QVariant(Record::typeName(Record::Type::UNDEFINED)));
+  QString typeName = lastRecordType.toString();
+  overlayControl->setCurrentText(typeName);
+  speedControl_->setCurrentText(kDefaultSpeed);
+  fileReader_.recordTypeChanged(typeName);
+
+  // Check which image frames need to be updated, rather than have them call update()
+  // in the decoding thread...
+  checkForUpdatesTimer_.setSingleShot(false);
+  checkForUpdatesTimer_.setTimerType(Qt::TimerType::PreciseTimer);
+  connect(&checkForUpdatesTimer_, &QTimer::timeout, this, &PlayerUI::checkForUpdates);
+  checkForUpdatesTimer_.start(1000 / 90); // delay between update checks
+}
+
+void PlayerUI::openFileChooser() {
+  setStatusText({});
+  QString dialogStartDir;
+  QFileInfo fileInfo(settings_.value(kLastFilePathSetting).toString());
+  if (fileInfo.exists()) {
+    dialogStartDir = fileInfo.isFile() ? fileInfo.absolutePath() : fileInfo.absoluteFilePath();
+  } else {
+    dialogStartDir = QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation)
+                         .value(0, QDir::homePath());
+  }
+  fileReader_.stop();
+  QFileDialog fileDialog(window());
+  fileDialog.setAcceptMode(QFileDialog::AcceptOpen);
+  fileDialog.setWindowTitle(tr("Open VRS File"));
+  fileDialog.setNameFilter("VRS files (*.vrs *.vrs-0)");
+  fileDialog.setDirectory(dialogStartDir);
+  if (fileDialog.exec() == QDialog::Accepted) {
+    openPath(fileDialog.selectedUrls().constFirst().toLocalFile());
+  }
+}
+
+void PlayerUI::openPathChooser() {
+  setStatusText({});
+  fileReader_.stop();
+  bool ok;
+  QString text = QInputDialog::getText(
+                     nullptr,
+                     "Open VRS File",
+                     "Path or URI:",
+                     QLineEdit::Normal,
+                     "",
+                     &ok,
+                     Qt::WindowFlags(),
+                     Qt::ImhMultiLine)
+                     .trimmed();
+  if (ok && !text.isEmpty()) {
+    openPath(text);
+  }
+}
+
+void PlayerUI::openLastFile() {
+  QString lastPath = settings_.value(kLastFilePathSetting).toString();
+  // Clear setting to avoid crash loops
+  settings_.setValue(kLastFilePathSetting, {});
+  if (!lastPath.isEmpty()) {
+    openPath(lastPath);
+  } else {
+    openFileChooser();
+  }
+}
+
+void PlayerUI::stopPressed() {
+  fileReader_.stop();
+}
+
+void PlayerUI::openPath(const QString& path) {
+  QString preparedPath = pathPreparer_ ? pathPreparer_(path) : path;
+  setStatusText({});
+  window()->setWindowTitle({});
+  frames_.clear();
+  frames_ = fileReader_.openFile(preparedPath, videoFrames_, window());
+  settings_.setValue(kLastFilePathSetting, frames_.empty() ? "" : preparedPath);
+  QVariant overlayColor = settings_.value(kOverlayColorSetting);
+  if (overlayColor.isValid()) {
+    setOverlayColor(overlayColor.value<QColor>());
+  }
+  resizeIfNecessary();
+}
+
+void PlayerUI::resizeToDefault() {
+  QSize fullSize = QApplication::desktop()->screenGeometry(this).size();
+  window()->setMaximumSize(fullSize);
+  // resize to default size & center on the current screen
+  window()->resize(fullSize * kDefaultScreenOccupationRatio);
+  window()->setGeometry(QStyle::alignedRect(
+      Qt::LeftToRight,
+      Qt::AlignCenter,
+      window()->size(),
+      qApp->desktop()->availableGeometry(window())));
+}
+
+void PlayerUI::resizeIfNecessary() {
+  QRect screenRect = QApplication::desktop()->screenGeometry(this);
+  QRect windowRect = geometry();
+  QRect windowInScreen(mapToGlobal(windowRect.topLeft()), mapToGlobal(windowRect.bottomRight()));
+  if (screenRect.contains(windowInScreen)) {
+    window()->setMaximumSize(screenRect.size());
+  } else {
+    resizeToDefault();
+  }
+}
+
+void PlayerUI::playPausePressed() {
+  switch (fileReader_.getState()) {
+    case FileReaderState::Playing:
+      fileReader_.pause();
+      break;
+    case FileReaderState::Paused:
+      fileReader_.play();
+      break;
+    default:
+      break;
+  }
+}
+
+void PlayerUI::backwardPressed() {
+  fileReader_.previousFrame();
+}
+
+void PlayerUI::forwardPressed() {
+  fileReader_.nextFrame();
+}
+
+void PlayerUI::checkForUpdates() {
+  for (auto frame : frames_) {
+    if (frame->getAndClearNeedsUpdate()) {
+      frame->update();
+    }
+  }
+}
+
+void PlayerUI::relayout(int framesPerRow) {
+  fileReader_.layoutFrames(videoFrames_, window(), framesPerRow);
+  resizeIfNecessary();
+}
+
+void PlayerUI::resetOrientation() {
+  emit fileReader_.resetOrientation();
+  resizeIfNecessary();
+}
+
+void PlayerUI::showAllStreams() {
+  emit fileReader_.enableAllStreams();
+  resizeIfNecessary();
+}
+
+void PlayerUI::toggleVisibleStreams() {
+  emit fileReader_.toggleVisibleStreams();
+  resizeIfNecessary();
+}
+
+void PlayerUI::savePreset() {
+  bool ok;
+  QString text = QInputDialog::getText(
+                     nullptr,
+                     "Save Prset",
+                     "Preset Name:",
+                     QLineEdit::Normal,
+                     "",
+                     &ok,
+                     Qt::WindowFlags(),
+                     Qt::ImhPreferLatin)
+                     .trimmed();
+  if (ok && !text.isEmpty()) {
+    fileReader_.savePreset(text);
+  }
+}
+
+void PlayerUI::recallPreset(const QString& preset) {
+  fileReader_.recallPreset(preset);
+  resizeIfNecessary();
+}
+
+void PlayerUI::deletePreset(const QString& preset) {
+  fileReader_.deletePreset(preset);
+}
+
+void PlayerUI::reportError(QString errorTitle, QString errorMessage) {
+  emit fileReader_.stop();
+  QMessageBox messageBox(QMessageBox::Critical, "", errorMessage, QMessageBox::Ok);
+  messageBox.QDialog::setWindowTitle(errorTitle); // Backdoor for MacOS
+  messageBox.setText(errorMessage);
+  messageBox.exec();
+}
+
+void PlayerUI::setOverlayColor(QColor color) {
+  fileReader_.setOverlayColor(color);
+  settings_.setValue(kOverlayColorSetting, color);
+}
+
+void PlayerUI::adjustSpeed(int change) {
+  if (change == 0) {
+    speedControl_->setCurrentText(kDefaultSpeed);
+  } else {
+    int count = speedControl_->count();
+    int currentSpeed = speedControl_->currentIndex();
+    int newSpeed = currentSpeed + change;
+    if (newSpeed >= 0 && newSpeed < count) {
+      speedControl_->setCurrentIndex(newSpeed);
+    }
+  }
+}
+
+void PlayerUI::mediaStateChanged(FileReaderState state) {
+  switch (state) {
+    case FileReaderState::NoMedia:
+      stopButton_->setEnabled(false);
+      playPauseButton_->setIcon(style()->standardIcon(QStyle::SP_MediaPlay));
+      playPauseButton_->setEnabled(false);
+      backwardButton_->setEnabled(false);
+      forwardButton_->setEnabled(false);
+      break;
+    case FileReaderState::Paused:
+      stopButton_->setEnabled(!fileReader_.isAtBegin());
+      playPauseButton_->setIcon(style()->standardIcon(QStyle::SP_MediaPlay));
+      playPauseButton_->setEnabled(!fileReader_.isAtEnd());
+      backwardButton_->setEnabled(!fileReader_.isAtBegin());
+      forwardButton_->setEnabled(!fileReader_.isAtEnd());
+      break;
+    case FileReaderState::Playing:
+      stopButton_->setEnabled(true);
+      playPauseButton_->setIcon(style()->standardIcon(QStyle::SP_MediaPause));
+      playPauseButton_->setEnabled(true);
+      backwardButton_->setEnabled(false);
+      forwardButton_->setEnabled(false);
+      break;
+    default:
+      stopButton_->setEnabled(false);
+      playPauseButton_->setIcon(style()->standardIcon(QStyle::SP_MediaPlay));
+      playPauseButton_->setEnabled(false);
+      backwardButton_->setEnabled(false);
+      forwardButton_->setEnabled(false);
+      break;
+  }
+}
+
+void PlayerUI::timeChanged(double time, int position) {
+  time_->setText(fmt::format("{:.3f}", time).c_str());
+  positionSlider_->setValue(position);
+}
+
+void PlayerUI::recordTypeChanged(int index) {
+  if (XR_VERIFY(index >= 0 && index < kRecordTypeLabels.size())) {
+    const QString& typeName = kRecordTypeLabels[index];
+    settings_.setValue(kLastRecordTypeSetting, typeName);
+    fileReader_.recordTypeChanged(typeName);
+  }
+}
+
+void PlayerUI::speedControlChanged(int index) {
+  double speed = 1;
+  if (XR_VERIFY(index >= 0 && index < kSpeeds.size())) {
+    speed = kSpeeds[index].second;
+  }
+  fileReader_.setPlaybackSpeed(speed);
+}
+
+void PlayerUI::durationChanged(double start, double end, int range) {
+  positionSlider_->setRange(0, range);
+  string tip = fmt::format(
+      "Start: {:.3f}\nEnd: {:.3f}\nDuration: {}",
+      start,
+      end,
+      vrs::helpers::humanReadableDuration(end - start).c_str());
+  time_->setToolTip(QString::fromUtf8(tip.c_str()));
+}
+
+void PlayerUI::setStatusText(const string& statusText) {
+  if (!statusText.empty() && isalnum(*statusText.rbegin())) {
+    statusLabel_->setText((statusText + '.').c_str());
+  } else {
+    statusLabel_->setText(statusText.c_str());
+  }
+}
+
+bool PlayerUI::eventFilter(QObject* obj, QEvent* event) {
+  return fileReader_.eventFilter(obj, event);
+}
+
+} // namespace vrsp

--- a/tools/vrsplayer/PlayerUI.h
+++ b/tools/vrsplayer/PlayerUI.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <functional>
+#include <vector>
+
+#include <QtCore/qglobal.h>
+#include <qcombobox.h>
+#include <qgraphicsscene.h>
+#include <qpixmap.h>
+#include <qsettings.h>
+#include <qwidget.h>
+
+#include "FileReader.h"
+
+QT_BEGIN_NAMESPACE
+class QHBoxLayout;
+class QAbstractButton;
+class QSlider;
+class QLabel;
+class QUrl;
+QT_END_NAMESPACE
+
+namespace vrsp {
+
+using PathPreparer = std::function<QString(const QString&)>;
+
+class PlayerUI : public QWidget {
+  Q_OBJECT
+ public:
+  PlayerUI(QWidget* parent = nullptr);
+
+  void setPathPreparer(const PathPreparer& pathPreparer) {
+    pathPreparer_ = pathPreparer;
+  }
+
+  void openPath(const QString& url);
+  void resizeToDefault();
+  void resizeIfNecessary();
+  FileReader& getFileReader() {
+    return fileReader_;
+  }
+
+ signals:
+
+ public slots:
+  void openFileChooser();
+  void openPathChooser();
+  void openLastFile();
+  void backwardPressed();
+  void stopPressed();
+  void playPausePressed();
+  void forwardPressed();
+  void checkForUpdates();
+  void relayout(int framesPerRow);
+  void resetOrientation();
+  void showAllStreams();
+  void toggleVisibleStreams();
+  void savePreset();
+  void recallPreset(const QString& preset);
+  void deletePreset(const QString& preset);
+  void reportError(QString errorTitle, QString errorMessage);
+  void setOverlayColor(QColor color);
+  void adjustSpeed(int change);
+
+ private slots:
+  void mediaStateChanged(FileReaderState state);
+  void durationChanged(double start, double end, int duration);
+  void timeChanged(double time, int position);
+  void recordTypeChanged(int index);
+  void speedControlChanged(int index);
+  void setStatusText(const std::string& statusText);
+  bool eventFilter(QObject* obj, QEvent* event);
+
+ private:
+  QSettings settings_;
+  FileReader fileReader_;
+  QVBoxLayout* videoFrames_;
+  std::vector<FrameWidget*> frames_;
+  QAbstractButton* backwardButton_;
+  QAbstractButton* stopButton_;
+  QAbstractButton* playPauseButton_;
+  QAbstractButton* forwardButton_;
+  QComboBox* speedControl_;
+  QLabel* time_;
+  QSlider* positionSlider_;
+  QLabel* statusLabel_;
+  QTimer checkForUpdatesTimer_;
+  PathPreparer pathPreparer_;
+};
+
+} // namespace vrsp

--- a/tools/vrsplayer/PlayerWindow.cpp
+++ b/tools/vrsplayer/PlayerWindow.cpp
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PlayerWindow.h"
+
+#include <qaction.h>
+#include <qmenubar.h>
+#include <qmessagebox.h>
+
+#include <vrs/os/Platform.h>
+
+#include <vrs/FileHandler.h>
+
+using namespace vrsp;
+using namespace std;
+
+PlayerWindow::PlayerWindow(QApplication& app) : QMainWindow(nullptr) {
+  setCentralWidget(&player_);
+  app.installEventFilter(&player_);
+  createMenus();
+  connect(
+      &player_.getFileReader(),
+      &FileReader::updateLayoutMenu,
+      this,
+      &PlayerWindow::updateLayoutMenu);
+  setWindowFlags(windowFlags() | Qt::CustomizeWindowHint | Qt::WindowMinMaxButtonsHint);
+}
+
+int PlayerWindow::processCommandLine(QCommandLineParser& parser) {
+  if (!parser.positionalArguments().isEmpty()) {
+    const QString& arg = parser.positionalArguments().constFirst();
+    vrs::FileSpec fspec;
+    if (!arg.isEmpty() && fspec.fromPathJsonUri(arg.toStdString()) == 0) {
+      player_.openPath(arg);
+    }
+  } else {
+    player_.openLastFile();
+  }
+  player_.resizeToDefault();
+  show();
+  QApplication::setActiveWindow(this);
+  return QApplication::exec();
+}
+
+void PlayerWindow::createMenus() {
+  QAction* aboutAction = new QAction("About " + QApplication::applicationName() + "...", this);
+  aboutAction->setStatusTip("About this application");
+  connect(aboutAction, &QAction::triggered, [this] {
+    QMessageBox::about(
+        this,
+        "About " + QApplication::applicationName(),
+        QApplication::applicationDisplayName() + " " + QApplication::applicationVersion() +
+            ",  by " + QApplication::organizationName() + ".");
+  });
+#if IS_MAC_PLATFORM()
+  // Will merge the menu item in the app's main menu. Unique MacOS behavior.
+  QMenu* appMenu = menuBar()->addMenu(QApplication::applicationName());
+  appMenu->addAction(aboutAction);
+#endif
+
+  fileMenu_ = menuBar()->addMenu("&File");
+
+  QAction* openAction = new QAction("&Open Local File...", this);
+  openAction->setShortcuts(QKeySequence::Open);
+  openAction->setStatusTip("Open a local file");
+  connect(openAction, &QAction::triggered, &player_, &vrsp::PlayerUI::openFileChooser);
+  fileMenu_->addAction(openAction);
+
+  QAction* openPathOrUriAction = new QAction("Open Path or URI...", this);
+  openPathOrUriAction->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_O);
+  openPathOrUriAction->setStatusTip("Open a recording using a path or URI...");
+  connect(openPathOrUriAction, &QAction::triggered, &player_, &vrsp::PlayerUI::openPathChooser);
+  fileMenu_->addAction(openPathOrUriAction);
+
+#if !IS_MAC_PLATFORM()
+  fileMenu_->addSeparator();
+  fileMenu_->addAction(aboutAction);
+#endif
+
+  colorMenu_ = menuBar()->addMenu("Text Color");
+  QAction* white = new QAction("Use White", this);
+  connect(white, &QAction::triggered, [this]() { player_.setOverlayColor(Qt::white); });
+  colorMenu_->addAction(white);
+  QAction* black = new QAction("Use Black", this);
+  connect(black, &QAction::triggered, [this]() { player_.setOverlayColor(Qt::black); });
+  colorMenu_->addAction(black);
+  QAction* green = new QAction("Use Green", this);
+  connect(green, &QAction::triggered, [this]() { player_.setOverlayColor(Qt::green); });
+  colorMenu_->addAction(green);
+  QAction* red = new QAction("Use Red", this);
+  connect(red, &QAction::triggered, [this]() { player_.setOverlayColor(Qt::red); });
+  colorMenu_->addAction(red);
+  QAction* blue = new QAction("Use Blue", this);
+  connect(blue, &QAction::triggered, [this]() { player_.setOverlayColor(Qt::blue); });
+  colorMenu_->addAction(blue);
+  QAction* yellow = new QAction("Use Yellow", this);
+  connect(yellow, &QAction::triggered, [this]() { player_.setOverlayColor(Qt::yellow); });
+  colorMenu_->addAction(yellow);
+  QAction* cyan = new QAction("Use Cyan", this);
+  connect(cyan, &QAction::triggered, [this]() { player_.setOverlayColor(Qt::cyan); });
+  colorMenu_->addAction(cyan);
+  QAction* magenta = new QAction("Use Magenta", this);
+  connect(magenta, &QAction::triggered, [this]() { player_.setOverlayColor(Qt::magenta); });
+  colorMenu_->addAction(magenta);
+
+  layoutMenu_ = menuBar()->addMenu("Layout");
+
+  orientationMenu_ = menuBar()->addMenu("Orientation");
+  QAction* resetAction = new QAction("Reset All Orientation Settings", this);
+  resetAction->setStatusTip("Reset all rotation and mirror settings.");
+  connect(resetAction, &QAction::triggered, &player_, &vrsp::PlayerUI::resetOrientation);
+  orientationMenu_->addAction(resetAction);
+}
+
+void PlayerWindow::updateLayoutMenu(
+    int frameCount,
+    int visibleCount,
+    int maxPerRowCount,
+    const QVariantMap& presets,
+    const QVariant& currentPreset) {
+  layoutMenu_->clear();
+  layoutActions_.clear();
+  if (visibleCount < frameCount) {
+    unique_ptr<QAction> layoutAction = make_unique<QAction>(QString("Show All Streams"), this);
+    connect(layoutAction.get(), &QAction::triggered, [this]() { player_.showAllStreams(); });
+    layoutMenu_->addAction(layoutAction.get());
+    layoutActions_.emplace_back(std::move(layoutAction));
+    unique_ptr<QAction> toggleAction =
+        make_unique<QAction>(QString("Toggle Visible Streams"), this);
+    connect(toggleAction.get(), &QAction::triggered, [this]() { player_.toggleVisibleStreams(); });
+    layoutMenu_->addAction(toggleAction.get());
+    layoutActions_.emplace_back(std::move(toggleAction));
+    layoutMenu_->addSeparator();
+  }
+  set<QString> deleteKeys;
+  int number = 0;
+  for (const auto& key : presets.keys()) {
+    unique_ptr<QAction> recallAction;
+    if (presets[key] == currentPreset) {
+      recallAction = make_unique<QAction>(QString("Current Preset '" + key + "'"), this);
+      recallAction->setCheckable(true);
+      recallAction->setChecked(true);
+      deleteKeys.insert(key);
+    } else {
+      recallAction = make_unique<QAction>(QString("Recall Preset '" + key + "'"), this);
+    }
+    if (++number < 10) {
+      recallAction->setShortcut(Qt::CTRL + Qt::Key_0 + number);
+    }
+    connect(recallAction.get(), &QAction::triggered, [this, key]() { player_.recallPreset(key); });
+    layoutMenu_->addAction(recallAction.get());
+    layoutActions_.emplace_back(std::move(recallAction));
+  }
+  if (!presets.empty()) {
+    layoutMenu_->addSeparator();
+  }
+  if (!deleteKeys.empty()) {
+    for (const auto& key : deleteKeys) {
+      unique_ptr<QAction> deleteAction;
+      deleteAction = make_unique<QAction>(QString("Delete Preset '" + key + "'"), this);
+      connect(
+          deleteAction.get(), &QAction::triggered, [this, key]() { player_.deletePreset(key); });
+      layoutMenu_->addAction(deleteAction.get());
+      layoutActions_.emplace_back(std::move(deleteAction));
+    }
+  } else {
+    unique_ptr<QAction> saveAction = make_unique<QAction>(QString("Save Preset"), this);
+    connect(saveAction.get(), &QAction::triggered, [this]() { player_.savePreset(); });
+    layoutMenu_->addAction(saveAction.get());
+    layoutActions_.emplace_back(std::move(saveAction));
+  }
+  layoutMenu_->addSeparator();
+  for (int layout = 1; layout <= visibleCount; layout++) {
+    unique_ptr<QAction> layoutAction = make_unique<QAction>(
+        QString("Layout Frames ") + QString::number(layout) + 'x' +
+            QString::number((visibleCount + layout - 1) / layout),
+        this);
+    connect(
+        layoutAction.get(), &QAction::triggered, [this, layout]() { player_.relayout(layout); });
+    if (layout == maxPerRowCount) {
+      layoutAction->setCheckable(true);
+      layoutAction->setChecked(true);
+    }
+    layoutMenu_->addAction(layoutAction.get());
+    layoutActions_.emplace_back(std::move(layoutAction));
+  }
+}

--- a/tools/vrsplayer/PlayerWindow.h
+++ b/tools/vrsplayer/PlayerWindow.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <QAction>
+#include <QApplication>
+#include <QMainWindow>
+#include <QtCore/QCommandLineParser>
+
+#include "PlayerUI.h"
+
+namespace vrsp {
+
+class PlayerWindow : public QMainWindow {
+  Q_OBJECT
+ public:
+  explicit PlayerWindow(QApplication& app);
+
+  int processCommandLine(QCommandLineParser& parser);
+
+  void createMenus();
+
+  FileReader& getFileReader() {
+    return player_.getFileReader();
+  }
+  PlayerUI& getPlayerUI() {
+    return player_;
+  }
+
+ signals:
+
+ public slots:
+  void updateLayoutMenu(
+      int frameCount,
+      int visibleCount,
+      int maxPerRowCount,
+      const QVariantMap& presets,
+      const QVariant& currentPreset);
+
+ private:
+  PlayerUI player_;
+  QMenu* fileMenu_;
+  QMenu* layoutMenu_;
+  QMenu* orientationMenu_;
+  QMenu* colorMenu_;
+  std::vector<std::unique_ptr<QAction>> layoutActions_;
+};
+
+} // namespace vrsp

--- a/tools/vrsplayer/VideoTime.cpp
+++ b/tools/vrsplayer/VideoTime.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "VideoTime.h"
+
+#include <sstream>
+
+#include <qmetaobject.h>
+
+#include <portaudio.h>
+
+#define DEFAULT_LOG_CHANNEL "VideoTime"
+#include <logging/Log.h>
+
+#include <vrs/os/Time.h>
+
+#include "PlayerUI.h"
+
+namespace vrsp {
+
+using namespace std;
+
+PaStream* VideoTime::sAudioStream = nullptr;
+double VideoTime::sPlaybackSpeed = 1;
+bool VideoTime::sValidatedTime = false;
+double VideoTime::sFirstTimeAudioTime = 0;
+double VideoTime::sFirstClassicTime = 0;
+PlayerUI* VideoTime::sPlayerUI = nullptr;
+
+#define PA_TIME (Pa_GetStreamTime(sAudioStream))
+
+static string getAudioDeviceName() {
+  PaDeviceIndex defaultOutpuDeviceIndex = Pa_GetDefaultOutputDevice();
+  const PaDeviceInfo* info = Pa_GetDeviceInfo(defaultOutpuDeviceIndex);
+  return info ? info->name : "<unknown audio device>";
+}
+
+void VideoTime::setTimeAudioStreamSource(PaStream* audioStream) {
+  sAudioStream = audioStream;
+  resetValidation();
+}
+
+double VideoTime::getTime() const {
+  if (sAudioStream && playing_ && !sValidatedTime) {
+    validateTime();
+  }
+  return playing_ ? getRawTime() - offset_ : pausedtime_;
+}
+
+void VideoTime::resetValidation() {
+  sValidatedTime = false;
+  sFirstClassicTime = vrs::os::getTimestampSec();
+  sFirstTimeAudioTime = PA_TIME;
+}
+
+void VideoTime::validateTime() {
+  double gap = vrs::os::getTimestampSec() - sFirstClassicTime;
+  if (gap > 1) {
+    double audiogap = PA_TIME - sFirstTimeAudioTime;
+    double ratio = audiogap / gap;
+    QString title;
+    stringstream msg;
+    if (ratio <= 0) {
+      // dead audio time
+      title = "Audio Device Not Working";
+      msg << "The clock provided by the audio device named '" << getAudioDeviceName()
+          << "' doesn't appear to be working at all.";
+      sAudioStream = nullptr;
+      XR_LOGE("{}", msg.str());
+    } else if (ratio < 0.95) {
+      // audio time too slow
+      title = "Slow Audio Device";
+      msg << "The clock provided by the audio device named '" << getAudioDeviceName()
+          << "' doesn't appear to be going fast enough, "
+          << "since it's going only at about " << int(ratio * 100)
+          << "% of your system's clock speed.";
+      sAudioStream = nullptr;
+      XR_LOGE("{}", msg.str());
+    } else if (ratio < 1.05) {
+      // audio time is about right
+      sValidatedTime = true;
+    } else {
+      // audio time too fast
+      title = "Fast Audio Device";
+      msg << "The clock provided by the audio device named '" << getAudioDeviceName()
+          << "' appears to be too fast, "
+          << "since it's going at about " << int(ratio * 100) << "% of your system's clock speed.";
+      sAudioStream = nullptr;
+      XR_LOGE("{}", msg.str());
+    }
+    if (!sValidatedTime && sPlayerUI) {
+      msg << endl
+          << endl
+          << "VRSplayer will try using the system's clock instead." << endl
+          << endl
+          << "You could try to select a different default audio device using "
+          << "your system's preferences/control panel.";
+      QMetaObject::invokeMethod(
+          sPlayerUI,
+          "reportError",
+          Qt::AutoConnection,
+          Q_ARG(QString, title),
+          Q_ARG(QString, QString::fromStdString(msg.str())));
+    }
+  }
+}
+
+double VideoTime::getRawTime() {
+  return ((sAudioStream != nullptr) ? PA_TIME : vrs::os::getTimestampSec()) * sPlaybackSpeed;
+}
+
+} // namespace vrsp

--- a/tools/vrsplayer/VideoTime.h
+++ b/tools/vrsplayer/VideoTime.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <qobject.h>
+
+#include <vrs/os/Time.h>
+
+typedef void PaStream;
+
+namespace vrsp {
+
+class PlayerUI;
+
+class VideoTime {
+ public:
+  /// Get a time measurement unrelated to playback start/pause/stop
+  /// The time source might be a system clock (default),
+  /// or an audio stream clock, as appropriate.
+  static double getRawTime();
+  /// Set audio stream from which the raw time should be retrieved.
+  static void setTimeAudioStreamSource(PaStream* audioStream);
+
+  static void setPlayerUI(PlayerUI* ui) {
+    sPlayerUI = ui;
+  }
+
+  static void setPlaybackSpeed(double speed) {
+    sPlaybackSpeed = speed;
+  }
+
+  static double getPlaybackSpeed() {
+    return sPlaybackSpeed;
+  }
+
+  void start() {
+    if (!playing_) {
+      resetValidation();
+      setTime(pausedtime_);
+      playing_ = true;
+    }
+  }
+  void pause() {
+    if (playing_) {
+      pausedtime_ = getRawTime() - offset_;
+      playing_ = false;
+    }
+  }
+  void setTime(double time) {
+    pausedtime_ = time;
+    offset_ = getRawTime() - time;
+  }
+  double getTime() const;
+
+ private:
+  bool playing_ = false;
+  double pausedtime_{};
+  double offset_{};
+
+  static void resetValidation();
+  static void validateTime();
+
+  static bool sValidatedTime;
+  static double sFirstTimeAudioTime;
+  static double sFirstClassicTime;
+
+  static PaStream* sAudioStream;
+  static double sPlaybackSpeed;
+
+  static PlayerUI* sPlayerUI; // for error reporting
+};
+
+} // namespace vrsp

--- a/tools/vrsplayer/main.cpp
+++ b/tools/vrsplayer/main.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <array>
+
+#include <qapplication.h>
+#include <qdir.h>
+
+#include <vrs/os/Platform.h>
+
+#if IS_VRS_FB_INTERNAL()
+#include <qplugin.h>
+
+#if defined(Q_OS_LINUX)
+Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
+#elif defined(Q_OS_MACOS)
+Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin);
+#elif defined(Q_OS_WIN)
+Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)
+#endif
+#endif
+
+#include <logging/LogLevel.h>
+
+#include "PlayerWindow.h"
+
+using namespace std;
+
+namespace {
+
+using namespace vrs;
+
+#if defined(Q_OS_LINUX)
+void platformConfig() {
+  // The default build config seems to be unable to locate fonts
+  // Give QT a hint via the QT_QPA_FONTDIR env var
+  auto fontdir = qgetenv("QT_QPA_FONTDIR");
+  if (fontdir.isEmpty()) {
+    // search some common font directories
+    array<QDir, 3> dirs{
+        QString{"/usr/share/fonts/truetype/"},
+        QString{"/usr/share/fonts/gnu-free/"},
+    };
+    for (const auto& dir : dirs) {
+      if (dir.exists() && !dir.isEmpty()) {
+        qputenv("QT_QPA_FONTDIR", dir.path().toUtf8());
+        break;
+      }
+    }
+  }
+}
+#else
+void platformConfig() {}
+#endif
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  ::arvr::logging::setGlobalLogLevel(arvr::logging::Level::Info);
+
+  platformConfig();
+  QApplication app(argc, argv);
+
+  QApplication::setStyle("Fusion");
+
+  qRegisterMetaType<FileReaderState>();
+
+  QCoreApplication::setApplicationName("VRSplayer");
+  QCoreApplication::setOrganizationName("Meta Reality Labs");
+  QGuiApplication::setApplicationDisplayName(QCoreApplication::applicationName());
+  QCoreApplication::setApplicationVersion("v2.0.0");
+
+  QCommandLineParser parser;
+  parser.setApplicationDescription("VRSplayer");
+  parser.addHelpOption();
+  parser.addVersionOption();
+  parser.addPositionalArgument("url", "https://about.facebook.com/realitylabs/");
+  parser.process(app);
+
+  vrsp::PlayerWindow playerWindow(app);
+
+  return playerWindow.processCommandLine(parser);
+}


### PR DESCRIPTION
Summary:
We're open sourcing vrsplayer. This diff moves vrsplayer's core code to the public oss/tools/vrsplayer folder. The new ossvrsplayer buck target allows us to build and run the code using pretty much the same as in OSS, to validate completeness.
Next step: create a cmake build target to the OSS build system to build vrsplayer in OSS.

Reviewed By: kiminoue7

Differential Revision: D36929185

