### PR TITLE
Update to Qt6 compatible APIs

### DIFF
--- a/tools/vrsplayer/CMakeLists.txt
+++ b/tools/vrsplayer/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_package(QT NAMES Qt5 COMPONENTS Core Gui Widgets)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core Gui Widgets)
 if (QT_FOUND)
   message(STATUS "Found Qt${QT_VERSION_MAJOR}, including vrsplayer target")
   find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Widgets)

--- a/tools/vrsplayer/FileReader.cpp
+++ b/tools/vrsplayer/FileReader.cpp
@@ -23,13 +23,18 @@
 
 #include <qapplication.h>
 #include <qboxlayout.h>
-#include <qdesktopwidget.h>
 #include <qevent.h>
 #include <qjsonarray.h>
 #include <qjsondocument.h>
 #include <qjsonobject.h>
 #include <qprogressdialog.h>
 #include <qstring.h>
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+#include <qdesktopwidget.h>
+#else
+#include <qscreen.h>
+#endif
 
 #define DEFAULT_LOG_CHANNEL "FileReader"
 #include <logging/Log.h>
@@ -344,7 +349,11 @@ vector<FrameWidget*> FileReader::openFile(QVBoxLayout* videoFrames, QWidget* wid
         relayout();
       } else {
         // Go over layout options, to find the one that matches the screen's aspect ratio the best
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
         QSize screenSize = QApplication::desktop()->screenGeometry(widget).size();
+#else
+        QSize screenSize = widget->screen()->size();
+#endif
         float screenRatio = static_cast<float>(screenSize.width()) / screenSize.height();
         // screenRatio = 1.77; // 24" monitor simulation
         // screenRatio = 2560.0f / 1600; // 30" monitor simulation

--- a/tools/vrsplayer/FileReader.h
+++ b/tools/vrsplayer/FileReader.h
@@ -42,7 +42,9 @@ class QVBoxLayout;
 QT_END_NAMESPACE
 
 enum class FileReaderState { Undefined, NoMedia, Paused, Playing, Error, Count };
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 Q_DECLARE_METATYPE(FileReaderState)
+#endif
 
 namespace vrsp {
 

--- a/tools/vrsplayer/FrameWidget.cpp
+++ b/tools/vrsplayer/FrameWidget.cpp
@@ -19,11 +19,15 @@
 #include <sstream>
 
 #include <qapplication.h>
-#include <qdesktopwidget.h>
-#include <qimage.h>
 #include <qmenu.h>
 #include <qpainter.h>
 #include <qsizepolicy.h>
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+#include <qdesktopwidget.h>
+#else
+#include <qscreen.h>
+#endif
 
 #define DEFAULT_LOG_CHANNEL "FrameWidget"
 #include <logging/Log.h>
@@ -169,8 +173,12 @@ void FrameWidget::updateMinMaxSize() {
     QSize size = getImageSize();
     setMinimumSize(size.scaled(100, 100, Qt::KeepAspectRatio));
     setBaseSize(size);
-    QSize screen = QApplication::desktop()->screenGeometry(this).size().operator*=(0.95);
-    setMaximumSize(size.scaled(screen, Qt::KeepAspectRatio));
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+    QSize screenSize = QApplication::desktop()->screenGeometry(this).size().operator*=(0.95);
+#else
+    QSize screenSize = screen()->geometry().size() * 0.95;
+#endif
+    setMaximumSize(size.scaled(screenSize, Qt::KeepAspectRatio));
   }
 }
 

--- a/tools/vrsplayer/PlayerUI.cpp
+++ b/tools/vrsplayer/PlayerUI.cpp
@@ -77,7 +77,11 @@ class JumpSlider : public QSlider {
     initStyleOption(&opt);
     QRect sr = style()->subControlRect(QStyle::CC_Slider, &opt, QStyle::SC_SliderHandle, this);
     if (event->button() == Qt::LeftButton && sr.contains(event->pos()) == false) {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
       int newVal = minimum() + ((maximum() - minimum()) * event->x()) / width();
+#else
+      int newVal = minimum() + ((maximum() - minimum()) * event->position().x()) / width();
+#endif
       event->accept();
       sliderMoved(newVal);
     }
@@ -271,7 +275,11 @@ void PlayerUI::openPath(const QString& path) {
 }
 
 void PlayerUI::resizeToDefault() {
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
   QSize fullSize = QApplication::desktop()->screenGeometry(this).size();
+#else
+  QSize fullSize = screen()->size();
+#endif
   window()->setMaximumSize(fullSize);
   // resize to default size & center on the current screen
   window()->resize(fullSize * kDefaultScreenOccupationRatio);
@@ -279,11 +287,19 @@ void PlayerUI::resizeToDefault() {
       Qt::LeftToRight,
       Qt::AlignCenter,
       window()->size(),
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
       qApp->desktop()->availableGeometry(window())));
+#else
+      screen()->geometry()));
+#endif
 }
 
 void PlayerUI::resizeIfNecessary() {
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
   QRect screenRect = QApplication::desktop()->screenGeometry(this);
+#else
+  QRect screenRect = screen()->geometry();
+#endif
   QRect windowRect = geometry();
   QRect windowInScreen(mapToGlobal(windowRect.topLeft()), mapToGlobal(windowRect.bottomRight()));
   if (screenRect.contains(windowInScreen)) {

--- a/tools/vrsplayer/PlayerWindow.cpp
+++ b/tools/vrsplayer/PlayerWindow.cpp
@@ -80,7 +80,7 @@ void PlayerWindow::createMenus() {
   fileMenu_->addAction(openAction);
 
   QAction* openPathOrUriAction = new QAction("Open Path or URI...", this);
-  openPathOrUriAction->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_O);
+  openPathOrUriAction->setShortcut(Qt::CTRL | Qt::SHIFT | Qt::Key_O);
   openPathOrUriAction->setStatusTip("Open a recording using a path or URI...");
   connect(openPathOrUriAction, &QAction::triggered, &player_, &vrsp::PlayerUI::openPathChooser);
   fileMenu_->addAction(openPathOrUriAction);
@@ -158,7 +158,7 @@ void PlayerWindow::updateLayoutMenu(
       recallAction = make_unique<QAction>(QString("Recall Preset '" + key + "'"), this);
     }
     if (++number < 10) {
-      recallAction->setShortcut(Qt::CTRL + Qt::Key_0 + number);
+      recallAction->setShortcut(Qt::CTRL | static_cast<Qt::Key>(Qt::Key_0 + number));
     }
     connect(recallAction.get(), &QAction::triggered, [this, key]() { player_.recallPreset(key); });
     layoutMenu_->addAction(recallAction.get());


### PR DESCRIPTION
Summary: To build with Qt6 is OSS, we need to update a few API calls deprecated in Qt6. In most cases, the new code works both with Qt5 and Qt6, but not always. With version checks, the code builds without warning both with Qt5 and Qt6.

Reviewed By: kiminoue7

Differential Revision: D36997864

