### PR TITLE
Fix missing libgmock-dev package in VRS open source

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
             sudo apt-get install \
-              cmake ninja-build ccache libgtest-dev libfmt-dev libcereal-dev \
+              cmake ninja-build ccache libgtest-dev libgmock-dev libfmt-dev libcereal-dev \
               libjpeg-dev libpng-dev \
               liblz4-dev libzstd-dev libxxhash-dev \
               libboost-system-dev libboost-filesystem-dev libboost-thread-dev libboost-chrono-dev libboost-date-time-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM ubuntu:focal
 
 # Get dependencies
 RUN apt-get update && DEBIAN_FRONTEND="noninteractive" TZ="America/New_York" apt-get install -y tzdata
-RUN apt-get install -y cmake ninja-build ccache libgtest-dev libfmt-dev libcereal-dev libjpeg-dev\
+RUN apt-get install -y cmake ninja-build ccache libgtest-dev libgmock-dev libfmt-dev libcereal-dev libjpeg-dev\
     libpng-dev liblz4-dev libzstd-dev libxxhash-dev\
     libboost-system-dev libboost-filesystem-dev libboost-thread-dev libboost-chrono-dev libboost-date-time-dev\
     qtbase5-dev portaudio19-dev\

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ doesn't install recent enough versions of cmake, fmt, lz4, and zstd._
 
 - install tools & libraries:
   ```
-  sudo apt-get install cmake ninja-build ccache libgtest-dev libfmt-dev libcereal-dev libjpeg-dev libpng-dev
+  sudo apt-get install cmake ninja-build ccache libgtest-dev libgmock-dev libfmt-dev libcereal-dev libjpeg-dev libpng-dev
   sudo apt-get install liblz4-dev libzstd-dev libxxhash-dev
   sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-thread-dev libboost-chrono-dev libboost-date-time-dev
   sudo apt-get install qtbase5-dev portaudio19-dev # for vrsplayer


### PR DESCRIPTION
Summary: A test introduced in a former diff utilized parts of the Google C++ testing lib (gtest/gmock) that was not available in the open source setup. This change makes sure that the required packages are installed.

Differential Revision: D38197235

