### PR TITLE
Add support for BAYER8_BGGR pixel format

### DIFF
--- a/vrs/RecordFormat.cpp
+++ b/vrs/RecordFormat.cpp
@@ -99,10 +99,12 @@ static_assert(static_cast<int>(ImageFormat::PNG) == 3, "ImageFormat enum values 
 static_assert(static_cast<int>(ImageFormat::VIDEO) == 4, "ImageFormat enum values CHANGED!");
 
 // These text names may NEVER BE CHANGED, as they are used in data layout definitions!!
-const char* sPixelFormatNames[] = {
-    "undefined", "grey8",      "bgr8",    "depth32f",    "rgb8",   "yuv_i420_split",  "rgba8",
-    "rgb10",     "rgb12",      "grey10",  "grey12",      "grey16", "rgb32F",          "scalar64F",
-    "yuy2",      "rgb_ir_4x4", "rgba32F", "bayer8_rggb", "raw10",  "raw10_bayer_rggb"};
+const char* sPixelFormatNames[] = {"undefined",  "grey8",          "bgr8",   "depth32f",
+                                   "rgb8",       "yuv_i420_split", "rgba8",  "rgb10",
+                                   "rgb12",      "grey10",         "grey12", "grey16",
+                                   "rgb32F",     "scalar64F",      "yuy2",   "rgb_ir_4x4",
+                                   "rgba32F",    "bayer8_rggb",    "raw10",  "raw10_bayer_rggb",
+                                   "bayer8_bggr"};
 
 struct PixelFormatConverter : public EnumStringConverter<
                                   PixelFormat,
@@ -130,6 +132,7 @@ static_assert(static_cast<int>(PixelFormat::RAW10) == 18, "PixelFormat enum valu
 static_assert(
     static_cast<int>(PixelFormat::RAW10_BAYER_RGGB) == 19,
     "PixelFormat enum values CHANGED!");
+static_assert(static_cast<int>(PixelFormat::BAYER8_BGGR) == 20, "PixelFormat enum values CHANGED!");
 const char* sAudioFormatNames[] = {"undefined", "pcm"};
 struct AudioFormatConverter : public EnumStringConverter<
                                   AudioFormat,
@@ -410,6 +413,7 @@ uint8_t ImageContentBlockSpec::getChannelCountPerPixel(PixelFormat pixel) {
     case PixelFormat::DEPTH32F:
     case PixelFormat::SCALAR64F:
     case PixelFormat::BAYER8_RGGB:
+    case PixelFormat::BAYER8_BGGR:
     case PixelFormat::RAW10_BAYER_RGGB:
     case PixelFormat::RAW10:
       return 1; // greyscale, or "depth", or any form of single numeric value per pixel
@@ -441,6 +445,7 @@ size_t ImageContentBlockSpec::getBytesPerPixel(PixelFormat pixel) {
     case PixelFormat::GREY8:
     case PixelFormat::RGB_IR_RAW_4X4:
     case PixelFormat::BAYER8_RGGB:
+    case PixelFormat::BAYER8_BGGR:
       return 1;
     case PixelFormat::GREY10:
     case PixelFormat::GREY12:

--- a/vrs/RecordFormat.h
+++ b/vrs/RecordFormat.h
@@ -82,6 +82,7 @@ enum class PixelFormat : uint8_t {
   BAYER8_RGGB, ///< 8 bit per pixel, RGGB bayer pattern.
   RAW10, ///< https://developer.android.com/reference/android/graphics/ImageFormat#RAW10
   RAW10_BAYER_RGGB, ///< 10 bit per pixel, RGGB bayer pattern.
+  BAYER8_BGGR, ///< 8 bit per pixel, BGGR bayer pattern.
 
   COUNT, ///< Count of values in this enum type. @internal
 };

--- a/vrs/utils/PixelFrame.cpp
+++ b/vrs/utils/PixelFrame.cpp
@@ -400,6 +400,7 @@ bool PixelFrame::normalizeFrame(shared_ptr<PixelFrame>& normalizedFrame, bool gr
     case PixelFormat::DEPTH32F:
     case PixelFormat::SCALAR64F:
     case PixelFormat::BAYER8_RGGB:
+    case PixelFormat::BAYER8_BGGR:
       format = PixelFormat::GREY8;
       componentCount = 1;
       break;
@@ -454,7 +455,7 @@ bool PixelFrame::normalizeFrame(shared_ptr<PixelFrame>& normalizedFrame, bool gr
   } else if (srcFormat == PixelFormat::SCALAR64F) {
     // normalize double pixels to grey8
     normalizeBuffer<double>(rdata(), normalizedFrame->wdata(), getWidth() * getHeight());
-  } else if (srcFormat == PixelFormat::BAYER8_RGGB) {
+  } else if (srcFormat == PixelFormat::BAYER8_RGGB || srcFormat == PixelFormat::BAYER8_BGGR) {
     // display as grey8(copy) for now
     const uint8_t* srcPtr = rdata();
     uint8_t* outPtr = normalizedFrame->wdata();


### PR DESCRIPTION
Summary: For some devices, we also need BAYER8_BGGR.

Differential Revision: D38677988

