### PR TITLE
Add jpeg-xl support to VRS (empty implementation)

### DIFF
--- a/vrs/RecordFormat.cpp
+++ b/vrs/RecordFormat.cpp
@@ -80,7 +80,7 @@ struct ContentTypeFormatConverter : public EnumStringConverter<
 };
 
 // These text names may NEVER BE CHANGED, as they are used in data layout definitions!!
-const char* sImageFormatNames[] = {"undefined", "raw", "jpg", "png", "video"};
+const char* sImageFormatNames[] = {"undefined", "raw", "jpg", "png", "video", "jxl"};
 struct ImageFormatConverter : public EnumStringConverter<
                                   ImageFormat,
                                   sImageFormatNames,
@@ -97,6 +97,7 @@ static_assert(static_cast<int>(ImageFormat::RAW) == 1, "ImageFormat enum values 
 static_assert(static_cast<int>(ImageFormat::JPG) == 2, "ImageFormat enum values CHANGED!");
 static_assert(static_cast<int>(ImageFormat::PNG) == 3, "ImageFormat enum values CHANGED!");
 static_assert(static_cast<int>(ImageFormat::VIDEO) == 4, "ImageFormat enum values CHANGED!");
+static_assert(static_cast<int>(ImageFormat::JXL) == 5, "ImageFormat enum values CHANGED!");
 
 // These text names may NEVER BE CHANGED, as they are used in data layout definitions!!
 const char* sPixelFormatNames[] = {

--- a/vrs/RecordFormat.h
+++ b/vrs/RecordFormat.h
@@ -53,6 +53,7 @@ enum class ImageFormat : uint8_t {
   JPG, ///< JPEG data.
   PNG, ///< PNG data.
   VIDEO, ///< Video codec encoded frame.
+  JXL, ///< JPEG-XL data.
   COUNT ///< Count of values in this enum type. @internal
 };
 

--- a/vrs/test/RecordFormatTest.cpp
+++ b/vrs/test/RecordFormatTest.cpp
@@ -76,6 +76,10 @@ TEST_F(RecordFormatTest, testBlockFormat) {
   EXPECT_EQ(jpg.getContentType(), ContentType::IMAGE);
   EXPECT_EQ(jpg.image().getImageFormat(), ImageFormat::JPG);
 
+  ContentBlock jxl("image/jxl");
+  EXPECT_EQ(jxl.getContentType(), ContentType::IMAGE);
+  EXPECT_EQ(jxl.image().getImageFormat(), ImageFormat::JXL);
+
   ContentBlock weird("image/weird");
   EXPECT_EQ(weird.getContentType(), ContentType::IMAGE);
   EXPECT_EQ(weird.image().getImageFormat(), ImageFormat::UNDEFINED);

--- a/vrs/utils/PixelFrame.cpp
+++ b/vrs/utils/PixelFrame.cpp
@@ -178,6 +178,8 @@ bool PixelFrame::readFrame(
       return frame->readPngFrame(reader, cb.getBlockSize());
     case ImageFormat::JPG:
       return frame->readJpegFrame(reader, cb.getBlockSize());
+    case ImageFormat::JXL:
+      return frame->readJxlFrame(reader, cb.getBlockSize());
     default:
       return false;
   }
@@ -224,6 +226,8 @@ bool PixelFrame::readCompressedFrame(const std::vector<uint8_t>& pixels, ImageFo
   switch (imageFormat) {
     case vrs::ImageFormat::JPG:
       return readJpegFrame(pixels);
+    case vrs::ImageFormat::JXL:
+      return readJxlFrame(pixels);
     case vrs::ImageFormat::PNG:
       return readPngFrame(pixels);
     default:

--- a/vrs/utils/PixelFrame.h
+++ b/vrs/utils/PixelFrame.h
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 
+#include <functional>
 #include <vector>
 
 // Make this class usable both when Qt is available, and when not
@@ -31,6 +32,8 @@
 #include <vrs/utils/VideoFrameHandler.h>
 
 namespace vrs::utils {
+
+using PixelFrameDecoder = std::function<bool(PixelFrame& out, const vector<uint8_t>&, bool decode)>;
 
 /// Helper class to read & convert images read using RecordFormat into simpler, but maybe degraded,
 /// pixel buffer, that can easily be displayed, or saved to disk as jpg or png.
@@ -136,6 +139,21 @@ class PixelFrame {
 
   static bool
   readJpegFrame(std::shared_ptr<PixelFrame>& frame, RecordReader* reader, const uint32_t sizeBytes);
+
+  /// Read a JPEG-XL encoded frame into the internal buffer.
+  /// @return True if the frame type is supported & the frame was read.
+  /// Returns false, if no decoder was installed, or the data couldn't be decoded correctly.
+  bool readJxlFrame(RecordReader* reader, const uint32_t sizeBytes);
+  /// Decode a JPEG-XL encoded frame into the internal buffer.
+  /// @param buffer: jpeg-xl data, possibly read from a valid jxl file (the whole file).
+  /// @param decodePixels: if true, decode the image in the buffer, otherwise, only read the format.
+  /// @return True if the frame type is supported & the frame was read.
+  /// Returns false, if no decoder was installed, or the data couldn't be decoded correctly.
+  bool readJxlFrame(const std::vector<uint8_t>& buffer, bool decodePixels = true);
+
+  /// Temporary: to avoid linkage issues, jepg-xl is optional for now and support is explicit.
+  /// At best, provide a decoder when the app is initialized, before using jpeg-xl images.
+  static void setJxlDecoder(const PixelFrameDecoder& decoder);
 
   /// Read a PNG encoded frame into the internal buffer.
   /// @param reader: The record reader to read data from.

--- a/vrs/utils/PixelFrameJxl.cpp
+++ b/vrs/utils/PixelFrameJxl.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PixelFrame.h"
+
+#define DEFAULT_LOG_CHANNEL "PixelFrameJxl"
+#include <logging/Log.h>
+#include <logging/Verify.h>
+
+namespace {
+
+vrs::utils::PixelFrameDecoder& jxlDecoder() {
+  static vrs::utils::PixelFrameDecoder sJxlDecoder = nullptr;
+  return sJxlDecoder;
+}
+
+} // namespace
+
+namespace vrs::utils {
+
+using namespace std;
+
+void PixelFrame::setJxlDecoder(const PixelFrameDecoder& decoder) {
+  jxlDecoder() = decoder;
+}
+
+bool PixelFrame::readJxlFrame(RecordReader* reader, const uint32_t sizeBytes) {
+  if (sizeBytes == 0) {
+    return false; // empty image
+  }
+  // read JPEG-XL data
+  vector<uint8_t> jxlBuf;
+  jxlBuf.resize(sizeBytes);
+  if (!XR_VERIFY(reader->read(jxlBuf.data(), sizeBytes) == 0)) {
+    return false;
+  }
+  return readJxlFrame(jxlBuf);
+}
+
+bool PixelFrame::readJxlFrame(const vector<uint8_t>& jxlBuf, bool decodePixels) {
+  const vrs::utils::PixelFrameDecoder& decoder = jxlDecoder();
+  if (decoder) {
+    return decoder(*this, jxlBuf, decodePixels);
+  }
+  XR_LOGW_EVERY_N_SEC(10, "Can't decode jxl frame, because no jxl decoder was provided.");
+  return false;
+}
+
+} // namespace vrs::utils


### PR DESCRIPTION
Summary:
This diff add support for jpeg-xl to VRS, but without actual jpeg-xl implementation.
The jpeg-xl library dependencies don't work everywhere, so we can't easily add support for jpeg-xl for everything. This diff adds all the definitions & placeholder locations in the VRS and pyvrs code, but without actual data decoder, to be added later.

Differential Revision: D38682433

