### PR TITLE
Rename map to attributesMap in classes with dictionary interface

### DIFF
--- a/pyvrs/vrs_bindings/utils/PyBuffer.cpp
+++ b/pyvrs/vrs_bindings/utils/PyBuffer.cpp
@@ -63,36 +63,36 @@ const constexpr char* kContentBlockBufferSizeKey = "buffer_size";
 
 namespace pyvrs {
 
-void PyImageContentBlockSpec::initMap() {
-  if (map.empty()) {
-    map[kImageSpecWidthKey] = PYWRAP(getWidth());
-    map[kImageSpecHeightKey] = PYWRAP(getHeight());
-    map[kImageSpecStrideKey] = PYWRAP(getStride());
-    map[kImageSpecPixelFormatKey] = PYWRAP(getPixelFormatAsString());
-    map[kImageSpecImageFormatKey] = PYWRAP(getImageFormatAsString());
-    map[kImageSpecBytesPerPixelKey] = PYWRAP(getBytesPerPixel());
-    map[kImageSpecBufferSizeKey] = PYWRAP(getBlockSize());
-    map[kImageSpecCodecNameKey] = PYWRAP(getCodecName());
-    map[kImageSpecCodecQualityKey] = PYWRAP(getCodecQuality());
-    map[kImageSpecKeyFrameTimestampKey] = PYWRAP(getKeyFrameTimestamp());
-    map[kImageSpecKeyFrameIndexKey] = PYWRAP(getKeyFrameIndex());
+void PyImageContentBlockSpec::initAttributesMap() {
+  if (attributesMap.empty()) {
+    attributesMap[kImageSpecWidthKey] = PYWRAP(getWidth());
+    attributesMap[kImageSpecHeightKey] = PYWRAP(getHeight());
+    attributesMap[kImageSpecStrideKey] = PYWRAP(getStride());
+    attributesMap[kImageSpecPixelFormatKey] = PYWRAP(getPixelFormatAsString());
+    attributesMap[kImageSpecImageFormatKey] = PYWRAP(getImageFormatAsString());
+    attributesMap[kImageSpecBytesPerPixelKey] = PYWRAP(getBytesPerPixel());
+    attributesMap[kImageSpecBufferSizeKey] = PYWRAP(getBlockSize());
+    attributesMap[kImageSpecCodecNameKey] = PYWRAP(getCodecName());
+    attributesMap[kImageSpecCodecQualityKey] = PYWRAP(getCodecQuality());
+    attributesMap[kImageSpecKeyFrameTimestampKey] = PYWRAP(getKeyFrameTimestamp());
+    attributesMap[kImageSpecKeyFrameIndexKey] = PYWRAP(getKeyFrameIndex());
   }
 }
 
-void PyAudioContentBlockSpec::initMap() {
-  if (map.empty()) {
-    map[kAudioSpecSampleCountKey] = PYWRAP(getSampleCount());
-    map[kAudioSpecSampleFormatKey] = PYWRAP(getSampleFormatAsString());
-    map[kAudioSpecSampleBlockStrideKey] = PYWRAP(getSampleBlockStride());
-    map[kAudioSpecChannelCountKey] = PYWRAP(getChannelCount());
-    map[kAudioSpecSampleRateKey] = PYWRAP(getSampleRate());
-    map[kAudioSpecBufferSizeKey] = PYWRAP(getBlockSize());
+void PyAudioContentBlockSpec::initAttributesMap() {
+  if (attributesMap.empty()) {
+    attributesMap[kAudioSpecSampleCountKey] = PYWRAP(getSampleCount());
+    attributesMap[kAudioSpecSampleFormatKey] = PYWRAP(getSampleFormatAsString());
+    attributesMap[kAudioSpecSampleBlockStrideKey] = PYWRAP(getSampleBlockStride());
+    attributesMap[kAudioSpecChannelCountKey] = PYWRAP(getChannelCount());
+    attributesMap[kAudioSpecSampleRateKey] = PYWRAP(getSampleRate());
+    attributesMap[kAudioSpecBufferSizeKey] = PYWRAP(getBlockSize());
   }
 }
 
-void PyContentBlock::initMap() {
-  if (map.empty()) {
-    map[kContentBlockBufferSizeKey] = PYWRAP(static_cast<uint32_t>(getBufferSize()));
+void PyContentBlock::initAttributesMap() {
+  if (attributesMap.empty()) {
+    attributesMap[kContentBlockBufferSizeKey] = PYWRAP(static_cast<uint32_t>(getBufferSize()));
   }
 }
 

--- a/pyvrs/vrs_bindings/utils/PyBuffer.h
+++ b/pyvrs/vrs_bindings/utils/PyBuffer.h
@@ -114,8 +114,8 @@ class PyImageContentBlockSpec {
     return spec_;
   }
 
-  void initMap();
-  map<string, py::object> map;
+  void initAttributesMap();
+  map<string, py::object> attributesMap;
 
  private:
   ImageContentBlockSpec spec_;
@@ -159,8 +159,8 @@ class PyAudioContentBlockSpec {
     return spec_.getSampleFormat();
   }
 
-  void initMap();
-  map<string, py::object> map;
+  void initAttributesMap();
+  map<string, py::object> attributesMap;
 
  private:
   AudioContentBlockSpec spec_;
@@ -181,8 +181,8 @@ class PyContentBlock {
     return blockSize == ContentBlock::kSizeUnknown ? -1 : static_cast<int>(blockSize);
   }
 
-  void initMap();
-  map<string, py::object> map;
+  void initAttributesMap();
+  map<string, py::object> attributesMap;
 
  private:
   ContentBlock block_;

--- a/pyvrs/vrs_bindings/utils/PyRecord.cpp
+++ b/pyvrs/vrs_bindings/utils/PyRecord.cpp
@@ -74,20 +74,21 @@ PyRecord::PyRecord(const IndexRecord::RecordInfo& info, int32_t recordIndex_, Re
   }
 }
 
-void PyRecord::initMap() {
-  if (map.empty()) {
-    map[kRecordFormatVersionKey] = PYWRAP(recordFormatVersion);
-    map[kRecordIndexKey] = PYWRAP(recordIndex);
-    map[kRecordTypeKey] = PYWRAP(recordType);
-    map[kRecordableIdKey] = PYWRAP(streamId);
-    map[kStreamIdKey] = PYWRAP(streamId);
-    map[kTimestampKey] = PYWRAP(recordTimestamp);
-    map[kImageCountKey] = PYWRAP(static_cast<uint32_t>(imageBlocks.size()));
-    map[kAudioBlockCountKey] = PYWRAP(static_cast<uint32_t>(audioBlocks.size()));
-    map[kCustomBlockCountKey] = PYWRAP(static_cast<uint32_t>(customBlocks.size()));
-    map[kMetadataCountKey] = PYWRAP(static_cast<uint32_t>(datalayoutBlocks.size()));
+void PyRecord::initAttributesMap() {
+  if (attributesMap.empty()) {
+    attributesMap[kRecordFormatVersionKey] = PYWRAP(recordFormatVersion);
+    attributesMap[kRecordIndexKey] = PYWRAP(recordIndex);
+    attributesMap[kRecordTypeKey] = PYWRAP(recordType);
+    attributesMap[kRecordableIdKey] = PYWRAP(streamId);
+    attributesMap[kStreamIdKey] = PYWRAP(streamId);
+    attributesMap[kTimestampKey] = PYWRAP(recordTimestamp);
+    attributesMap[kImageCountKey] = PYWRAP(static_cast<uint32_t>(imageBlocks.size()));
+    attributesMap[kAudioBlockCountKey] = PYWRAP(static_cast<uint32_t>(audioBlocks.size()));
+    attributesMap[kCustomBlockCountKey] = PYWRAP(static_cast<uint32_t>(customBlocks.size()));
+    attributesMap[kMetadataCountKey] = PYWRAP(static_cast<uint32_t>(datalayoutBlocks.size()));
     if (!unsupportedBlocks.empty()) {
-      map[kUnsupportedBlockCountKey] = PYWRAP(static_cast<uint32_t>(unsupportedBlocks.size()));
+      attributesMap[kUnsupportedBlockCountKey] =
+          PYWRAP(static_cast<uint32_t>(unsupportedBlocks.size()));
     }
   }
 }

--- a/pyvrs/vrs_bindings/utils/PyRecord.h
+++ b/pyvrs/vrs_bindings/utils/PyRecord.h
@@ -80,8 +80,8 @@ struct PyRecord {
   vector<PyImageContentBlockSpec> imageSpecs;
 
   /// members and methods to set up dictionary interface.
-  void initMap();
-  map<string, py::object> map;
+  void initAttributesMap();
+  map<string, py::object> attributesMap;
 };
 
 /// Binds methods and classes for PyRecord.

--- a/pyvrs/vrs_bindings/utils/PyUtils.h
+++ b/pyvrs/vrs_bindings/utils/PyUtils.h
@@ -294,37 +294,37 @@ inline PyObject* pyObject(const char* s) {
 #define PYWRAP(val) pyWrap(pyObject(val))
 #define DEF_GETITEM(m, class)                                    \
   m.def("__getitem__", [](class& dict, const std::string& key) { \
-    dict.initMap();                                              \
+    dict.initAttributesMap();                                    \
     try {                                                        \
-      return dict.map.at(key);                                   \
+      return dict.attributesMap.at(key);                         \
     } catch (const std::out_of_range&) {                         \
       throw py::key_error("key '" + key + "' does not exist.");  \
     }                                                            \
   });
 
-#define DEF_LEN(m, class)       \
-  m.def(                        \
-      "__len__",                \
-      [](class& dict) {         \
-        dict.initMap();         \
-        return dict.map.size(); \
-      },                        \
+#define DEF_LEN(m, class)                 \
+  m.def(                                  \
+      "__len__",                          \
+      [](class& dict) {                   \
+        dict.initAttributesMap();         \
+        return dict.attributesMap.size(); \
+      },                                  \
       py::keep_alive<0, 1>());
-#define DEF_ITER(m, class)                                              \
-  m.def(                                                                \
-      "__iter__",                                                       \
-      [](class& dict) {                                                 \
-        dict.initMap();                                                 \
-        return py::make_key_iterator(dict.map.begin(), dict.map.end()); \
-      },                                                                \
+#define DEF_ITER(m, class)                                                                  \
+  m.def(                                                                                    \
+      "__iter__",                                                                           \
+      [](class& dict) {                                                                     \
+        dict.initAttributesMap();                                                           \
+        return py::make_key_iterator(dict.attributesMap.begin(), dict.attributesMap.end()); \
+      },                                                                                    \
       py::keep_alive<0, 1>());
-#define DEF_ITEM(m, class)                                          \
-  m.def(                                                            \
-      "items",                                                      \
-      [](class& dict) {                                             \
-        dict.initMap();                                             \
-        return py::make_iterator(dict.map.begin(), dict.map.end()); \
-      },                                                            \
+#define DEF_ITEM(m, class)                                                              \
+  m.def(                                                                                \
+      "items",                                                                          \
+      [](class& dict) {                                                                 \
+        dict.initAttributesMap();                                                       \
+        return py::make_iterator(dict.attributesMap.begin(), dict.attributesMap.end()); \
+      },                                                                                \
       py::keep_alive<0, 1>());
 #define DEF_DICT_FUNC(m, class) \
   DEF_GETITEM(m, class)         \


### PR DESCRIPTION
Summary: Member variable map causes a build error in ubuntu. To make it clear what this field is rename from map to attributesMap.

Reviewed By: georges-berenger

Differential Revision: D38886678

