### PR TITLE
Move jpeg compression code to PixelFrame

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,9 +24,11 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
-            sudo apt-get install \
+            sudo apt-get update
+            sudo apt-get upgrade
+            sudo apt-get install -o Acquire::Retries=5 \
               cmake ninja-build ccache libgtest-dev libfmt-dev libcereal-dev \
-              libjpeg-dev libpng-dev \
+              libturbojpeg-dev libpng-dev \
               liblz4-dev libzstd-dev libxxhash-dev \
               libboost-system-dev libboost-filesystem-dev libboost-thread-dev libboost-chrono-dev libboost-date-time-dev \
               qtbase5-dev portaudio19-dev
@@ -35,7 +37,7 @@ jobs:
 
           elif [ "$RUNNER_OS" == "macOS" ]; then
               brew install ninja cmake ccache googletest glog fmt cereal \
-                  jpeg libpng \
+                  jpeg-turbo libpng \
                   lz4 zstd xxhash \
                   boost \
                   qt5 portaudio pybind11

--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -28,16 +28,18 @@ jobs:
     - name: Install dependencies
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
-            sudo apt-get install \
+            sudo apt-get update
+            sudo apt-get upgrade
+            sudo apt-get install -o Acquire::Retries=5 \
               cmake ninja-build ccache libgtest-dev libfmt-dev libcereal-dev \
-              libjpeg-dev libpng-dev \
+              libturbojpeg-dev libpng-dev \
               liblz4-dev libzstd-dev libxxhash-dev \
               libboost-system-dev libboost-filesystem-dev libboost-thread-dev libboost-chrono-dev libboost-date-time-dev \
               portaudio19-dev
 
           elif [ "$RUNNER_OS" == "macOS" ]; then
               brew install ninja cmake ccache googletest glog fmt cereal \
-                  jpeg libpng \
+                  jpeg-turbo libpng \
                   lz4 zstd xxhash \
                   boost \
                   portaudio pybind11

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -18,9 +18,11 @@ jobs:
       uses: actions/checkout@v2
     - name: Install dependencies
       run: |
-        sudo apt-get install \
+        sudo apt-get update
+        sudo apt-get upgrade
+        sudo apt-get install -o Acquire::Retries=5 \
               cmake ninja-build ccache libgtest-dev libfmt-dev libcereal-dev \
-              libjpeg-dev libpng-dev \
+              libturbojpeg-dev libpng-dev \
               liblz4-dev libzstd-dev libxxhash-dev \
               libboost-system-dev libboost-filesystem-dev libboost-thread-dev libboost-chrono-dev libboost-date-time-dev \
               qtbase5-dev portaudio19-dev doxygen

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ avoid installing any library on your system.
   [Brew’s web site](https://brew.sh/).
 - install tools & libraries:
   ```
-  brew install cmake ninja ccache boost fmt cereal libpng jpeg lz4 zstd xxhash glog googletest
+  brew install cmake ninja ccache boost fmt cereal libpng jpeg-turbo lz4 zstd xxhash glog googletest
   brew install qt5 portaudio pybind11
   brew install node doxygen
   python -m pip install -U pip
@@ -93,7 +93,7 @@ doesn't install recent enough versions of cmake, fmt, lz4, and zstd._
 
 - install tools & libraries:
   ```
-  sudo apt-get install cmake ninja-build ccache libgtest-dev libfmt-dev libcereal-dev libjpeg-dev libpng-dev
+  sudo apt-get install cmake ninja-build ccache libgtest-dev libfmt-dev libcereal-dev libturbojpeg-dev libpng-dev
   sudo apt-get install liblz4-dev libzstd-dev libxxhash-dev
   sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-thread-dev libboost-chrono-dev libboost-date-time-dev
   sudo apt-get install qtbase5-dev portaudio19-dev

--- a/cmake/FindTurboJpeg.cmake
+++ b/cmake/FindTurboJpeg.cmake
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# - Find libjpeg-turbo
+# Find the libjpeg-turbo compression library and includes
+#
+# TurboJpeg_INCLUDE_DIRS - where to find turbojpeg.h, etc.
+# TurboJpeg_LIBRARIES - List of libraries when using TurboJpeg.
+# TurboJpeg_FOUND - True if TurboJpeg found.
+
+find_path(TurboJpeg_INCLUDE_DIRS NAMES turbojpeg.h)
+find_library(TurboJpeg_LIBRARIES NAMES libturbojpeg turbojpeg)
+mark_as_advanced(TurboJpeg_LIBRARIES TurboJpeg_INCLUDE_DIRS)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(TurboJpeg DEFAULT_MSG TurboJpeg_LIBRARIES TurboJpeg_INCLUDE_DIRS)
+
+if (TurboJpeg_FOUND AND NOT (TARGET TurboJpeg::TurboJpeg))
+  add_library(TurboJpeg::TurboJpeg UNKNOWN IMPORTED)
+  set_target_properties(TurboJpeg::TurboJpeg
+    PROPERTIES
+      IMPORTED_LOCATION ${TurboJpeg_LIBRARIES}
+      INTERFACE_INCLUDE_DIRECTORIES ${TurboJpeg_INCLUDE_DIRS}
+  )
+endif()

--- a/cmake/LibrariesSetup.cmake
+++ b/cmake/LibrariesSetup.cmake
@@ -27,6 +27,7 @@ find_package(Zstd REQUIRED)
 find_package(xxHash REQUIRED)
 find_package(PNG REQUIRED)
 find_package(JPEG REQUIRED)
+find_package(TurboJpeg REQUIRED)
 
 # Setup unit test infra, but only if unit tests are enabled
 if (UNIT_TESTS)

--- a/vrs/utils/CMakeLists.txt
+++ b/vrs/utils/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(vrs_utils
     fmt::fmt
     JPEG::JPEG
     PNG::PNG
+    TurboJpeg::TurboJpeg
     cereal::cereal
     vrs_logging
 )

--- a/vrs/utils/PixelFrame.h
+++ b/vrs/utils/PixelFrame.h
@@ -138,6 +138,27 @@ class PixelFrame {
   static bool
   readJpegFrame(std::shared_ptr<PixelFrame>& frame, RecordReader* reader, const uint32_t sizeBytes);
 
+  /// Compress pixel frame to jpg. Supports ImageFormat::RAW and PixelFormat::RGB8 or GREY8 only.
+  /// @param outBuffer: on exit, the jpg payload wich can be saved as a .jpg file
+  /// @param quality: jpg quality setting, from 1 to 100
+  /// @return True if the image and pixel formats are supported, the compression succeeded, and
+  /// outBuffer was set. If returning False, do not use outBuffer.
+  bool jpgCompress(std::vector<uint8_t>& outBuffer, uint32_t quality);
+
+  /// Compress pixel frame to jpg. See other variant of jpgCompress for specs.
+  /// @param pixelSpec: specs of the pixel buffer.
+  /// @param pixels: the raw pixel buffer.
+  /// @param outBuffer: on exit, the jpg payload wich can be saved as a .jpg file.
+  /// outBuffer may be the same as pixels.
+  /// @param quality: jpg quality setting, from 1 to 100
+  /// @return True if the image and pixel formats are supported, the compression succeeded, and
+  /// outBuffer was set. If returning False, do not use outBuffer.
+  static bool jpgCompress(
+      const ImageContentBlockSpec& pixelSpec,
+      const std::vector<uint8_t>& pixels,
+      std::vector<uint8_t>& outBuffer,
+      uint32_t quality);
+
   /// Read a JPEG-XL encoded frame into the internal buffer.
   /// @return True if the frame type is supported & the frame was read.
   /// Returns false, if no decoder was installed, or the data couldn't be decoded correctly.


### PR DESCRIPTION
Summary: This diff groups image jpg encoding functionality from unit test to PixelFrame, for reuse.

Differential Revision: D39787356

