### PR TITLE
Move jxl compression code to PixelFrame

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,9 +24,11 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
-            sudo apt-get install \
+            sudo apt-get update
+            sudo apt-get upgrade
+            sudo apt-get install -o Acquire::Retries=5 \
               cmake ninja-build ccache libgtest-dev libfmt-dev libcereal-dev \
-              libjpeg-dev libpng-dev \
+              libturbojpeg-dev libpng-dev \
               liblz4-dev libzstd-dev libxxhash-dev \
               libboost-system-dev libboost-filesystem-dev libboost-thread-dev libboost-chrono-dev libboost-date-time-dev \
               qtbase5-dev portaudio19-dev
@@ -35,7 +37,7 @@ jobs:
 
           elif [ "$RUNNER_OS" == "macOS" ]; then
               brew install ninja cmake ccache googletest glog fmt cereal \
-                  jpeg libpng \
+                  jpeg-turbo libpng \
                   lz4 zstd xxhash \
                   boost \
                   qt5 portaudio pybind11

--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -28,16 +28,18 @@ jobs:
     - name: Install dependencies
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
-            sudo apt-get install \
+            sudo apt-get update
+            sudo apt-get upgrade
+            sudo apt-get install -o Acquire::Retries=5 \
               cmake ninja-build ccache libgtest-dev libfmt-dev libcereal-dev \
-              libjpeg-dev libpng-dev \
+              libturbojpeg-dev libpng-dev \
               liblz4-dev libzstd-dev libxxhash-dev \
               libboost-system-dev libboost-filesystem-dev libboost-thread-dev libboost-chrono-dev libboost-date-time-dev \
               portaudio19-dev
 
           elif [ "$RUNNER_OS" == "macOS" ]; then
               brew install ninja cmake ccache googletest glog fmt cereal \
-                  jpeg libpng \
+                  jpeg-turbo libpng \
                   lz4 zstd xxhash \
                   boost \
                   portaudio pybind11

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -18,9 +18,11 @@ jobs:
       uses: actions/checkout@v2
     - name: Install dependencies
       run: |
-        sudo apt-get install \
+        sudo apt-get update
+        sudo apt-get upgrade
+        sudo apt-get install -o Acquire::Retries=5 \
               cmake ninja-build ccache libgtest-dev libfmt-dev libcereal-dev \
-              libjpeg-dev libpng-dev \
+              libturbojpeg-dev libpng-dev \
               liblz4-dev libzstd-dev libxxhash-dev \
               libboost-system-dev libboost-filesystem-dev libboost-thread-dev libboost-chrono-dev libboost-date-time-dev \
               qtbase5-dev portaudio19-dev doxygen

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ avoid installing any library on your system.
   [Brew’s web site](https://brew.sh/).
 - install tools & libraries:
   ```
-  brew install cmake ninja ccache boost fmt cereal libpng jpeg lz4 zstd xxhash glog googletest
+  brew install cmake ninja ccache boost fmt cereal libpng jpeg-turbo lz4 zstd xxhash glog googletest
   brew install qt5 portaudio pybind11
   brew install node doxygen
   python -m pip install -U pip
@@ -93,7 +93,7 @@ doesn't install recent enough versions of cmake, fmt, lz4, and zstd._
 
 - install tools & libraries:
   ```
-  sudo apt-get install cmake ninja-build ccache libgtest-dev libfmt-dev libcereal-dev libjpeg-dev libpng-dev
+  sudo apt-get install cmake ninja-build ccache libgtest-dev libfmt-dev libcereal-dev libturbojpeg-dev libpng-dev
   sudo apt-get install liblz4-dev libzstd-dev libxxhash-dev
   sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-thread-dev libboost-chrono-dev libboost-date-time-dev
   sudo apt-get install qtbase5-dev portaudio19-dev

--- a/cmake/FindTurboJpeg.cmake
+++ b/cmake/FindTurboJpeg.cmake
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# - Find libjpeg-turbo
+# Find the libjpeg-turbo compression library and includes
+#
+# TurboJpeg_INCLUDE_DIRS - where to find turbojpeg.h, etc.
+# TurboJpeg_LIBRARIES - List of libraries when using TurboJpeg.
+# TurboJpeg_FOUND - True if TurboJpeg found.
+
+find_path(TurboJpeg_INCLUDE_DIRS NAMES turbojpeg.h)
+find_library(TurboJpeg_LIBRARIES NAMES libturbojpeg turbojpeg)
+mark_as_advanced(TurboJpeg_LIBRARIES TurboJpeg_INCLUDE_DIRS)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(TurboJpeg DEFAULT_MSG TurboJpeg_LIBRARIES TurboJpeg_INCLUDE_DIRS)
+
+if (TurboJpeg_FOUND AND NOT (TARGET TurboJpeg::TurboJpeg))
+  add_library(TurboJpeg::TurboJpeg UNKNOWN IMPORTED)
+  set_target_properties(TurboJpeg::TurboJpeg
+    PROPERTIES
+      IMPORTED_LOCATION ${TurboJpeg_LIBRARIES}
+      INTERFACE_INCLUDE_DIRECTORIES ${TurboJpeg_INCLUDE_DIRS}
+  )
+endif()

--- a/cmake/LibrariesSetup.cmake
+++ b/cmake/LibrariesSetup.cmake
@@ -27,6 +27,7 @@ find_package(Zstd REQUIRED)
 find_package(xxHash REQUIRED)
 find_package(PNG REQUIRED)
 find_package(JPEG REQUIRED)
+find_package(TurboJpeg REQUIRED)
 
 # Setup unit test infra, but only if unit tests are enabled
 if (UNIT_TESTS)

--- a/vrs/utils/CMakeLists.txt
+++ b/vrs/utils/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(vrs_utils
     fmt::fmt
     JPEG::JPEG
     PNG::PNG
+    TurboJpeg::TurboJpeg
     cereal::cereal
     vrs_logging
 )

--- a/vrs/utils/PixelFrame.h
+++ b/vrs/utils/PixelFrame.h
@@ -138,6 +138,27 @@ class PixelFrame {
   static bool
   readJpegFrame(std::shared_ptr<PixelFrame>& frame, RecordReader* reader, const uint32_t sizeBytes);
 
+  /// Compress pixel frame to jpg. Supports ImageFormat::RAW and PixelFormat::RGB8 or GREY8 only.
+  /// @param outBuffer: on exit, the jpg payload wich can be saved as a .jpg file
+  /// @param quality: jpg quality setting, from 1 to 100
+  /// @return True if the image and pixel formats are supported, the compression succeeded, and
+  /// outBuffer was set. If returning False, do not use outBuffer.
+  bool jpgCompress(std::vector<uint8_t>& outBuffer, uint32_t quality);
+
+  /// Compress pixel frame to jpg. See other variant of jpgCompress for specs.
+  /// @param pixelSpec: specs of the pixel buffer.
+  /// @param pixels: the raw pixel buffer.
+  /// @param outBuffer: on exit, the jpg payload wich can be saved as a .jpg file.
+  /// outBuffer may be the same as pixels.
+  /// @param quality: jpg quality setting, from 1 to 100
+  /// @return True if the image and pixel formats are supported, the compression succeeded, and
+  /// outBuffer was set. If returning False, do not use outBuffer.
+  static bool jpgCompress(
+      const ImageContentBlockSpec& pixelSpec,
+      const std::vector<uint8_t>& pixels,
+      std::vector<uint8_t>& outBuffer,
+      uint32_t quality);
+
   /// Read a JPEG-XL encoded frame into the internal buffer.
   /// @return True if the frame type is supported & the frame was read.
   /// Returns false, if no decoder was installed, or the data couldn't be decoded correctly.

--- a/vrs/utils/PixelFrame.h
+++ b/vrs/utils/PixelFrame.h
@@ -170,6 +170,48 @@ class PixelFrame {
   /// Returns false, if no decoder was installed, or the data couldn't be decoded correctly.
   bool readJxlFrame(const std::vector<uint8_t>& buffer, bool decodePixels = true);
 
+  /// Compress pixel frame to jxl. Supports ImageFormat::RAW and PixelFormat::RGB8 or GREY8 only.
+  /// @param outBuffer: on exit, the jxl payload wich can be saved as a .jxl file
+  /// @param quality: jxl quality setting, from 20 to 100 for percentage, or 0 to 15 for distance.
+  /// @param percentNotDistance: if true quality is a percentage (default), 100% being lossless.
+  /// If false, quality is a Butteraugli distance (Google "Butteraugli" for details), where
+  /// Butteraugli distance 0 is lossless, and 15 is the worst Butteraugli distance supported.
+  /// 99.99% ~ Butteraugli 0.1, 99% ~ Butteraugli 0.2, 95.5% ~ Butteraugli 0.5, 90% ~ Butteraugli 1
+  /// @param effort: Sets encoder effort/speed level without affecting decoding speed.
+  /// Valid values are, from faster to slower speed: 1:lightning 2:thunder 3:falcon
+  /// 4:cheetah 5:hare 6:wombat 7:squirrel 8:kitten 9:tortoise.
+  /// 99.99% ~ Butteraugli 0.1, 99% ~ Butteraugli 0.2, 95.5% ~ Butteraugli 0.5, 90% ~ Butteraugli 1
+  /// @return True if the image and pixel formats are supported, the compression succeeded, and
+  /// outBuffer was set. If returning False, do not use outBuffer.
+  bool jxlCompress(
+      std::vector<uint8_t>& outBuffer,
+      float quality,
+      bool percentNotDistance = true,
+      int effort = 3);
+
+  /// Compress pixel frame to jxl. Supports ImageFormat::RAW and PixelFormat::RGB8 or GREY8 only.
+  /// @param pixelSpec: specs of the pixel buffer.
+  /// @param pixels: the raw pixel buffer.
+  /// @param outBuffer: on exit, the jxl payload wich can be saved as a .jxl file.
+  /// outBuffer may be the same as pixels.
+  /// @param quality: jxl quality setting, from 20 to 100 for percentage, or 0 to 15 for distance.
+  /// @param percentNotDistance: if true quality is a percentage (default), 100% being lossless.
+  /// If false, quality is a Butteraugli distance (Google "Butteraugli" for details), where
+  /// Butteraugli distance 0 is lossless, and 15 is the worst Butteraugli distance supported.
+  /// @param effort: Sets encoder effort/speed level without affecting decoding speed.
+  /// Valid values are, from faster to slower speed: 1:lightning 2:thunder 3:falcon
+  /// 4:cheetah 5:hare 6:wombat 7:squirrel 8:kitten 9:tortoise.
+  /// 99.99% ~ Butteraugli 0.1, 99% ~ Butteraugli 0.2, 95.5% ~ Butteraugli 0.5, 90% ~ Butteraugli 1
+  /// @return True if the image and pixel formats are supported, the compression succeeded, and
+  /// outBuffer was set. If returning False, do not use outBuffer.
+  static bool jxlCompress(
+      const ImageContentBlockSpec& pixelSpec,
+      const std::vector<uint8_t>& pixels,
+      std::vector<uint8_t>& outBuffer,
+      float quality,
+      bool percentNotDistance = true,
+      int effort = 3);
+
   /// Read a PNG encoded frame into the internal buffer.
   /// @param reader: The record reader to read data from.
   /// @param sizeBytes: Number of bytes to read from the reader.

--- a/vrs/utils/PixelFrameJxl.cpp
+++ b/vrs/utils/PixelFrameJxl.cpp
@@ -21,20 +21,44 @@
 #include <thread>
 
 #ifdef JXL_IS_AVAILABLE
+#include <jxl/color_encoding.h>
 #include <jxl/decode.h>
 #include <jxl/decode_cxx.h>
+#include <jxl/encode.h>
+#include <jxl/encode_cxx.h>
+#include <jxl/types.h>
 #endif
 
 #define DEFAULT_LOG_CHANNEL "PixelFrameJxl"
+#include <logging/Checks.h>
 #include <logging/Log.h>
 #include <logging/Verify.h>
 
 #ifdef JXL_IS_AVAILABLE
 
-#define JXL_CHECK(operation_)                         \
+/// About Jpeg-XL support
+/// This code requires Jpeg-XL v0.7 (won't compile with v0.61)
+/// Jpeg-XL is support is still considered experimental, as the API still changes in breaking ways,
+/// which is why support is disabled by default in VRS OSS.
+/// As of Sep 23, 2022, get jpg-xl from https://github.com/libjxl and use the v0.7.x branch
+
+#include <vrs/helpers/MemBuffer.h>
+
+#define DEC_CHECK(operation_)                         \
   do {                                                \
     JxlDecoderStatus status_ = operation_;            \
     if (status_ != JXL_DEC_SUCCESS) {                 \
+      XR_LOGE("{} failed: {}", #operation_, status_); \
+      return false;                                   \
+    }                                                 \
+  } while (false)
+
+#define JXL_EFFORT 3
+
+#define ENC_CHECK(operation_)                         \
+  do {                                                \
+    JxlEncoderStatus status_ = operation_;            \
+    if (status_ != JXL_ENC_SUCCESS) {                 \
       XR_LOGE("{} failed: {}", #operation_, status_); \
       return false;                                   \
     }                                                 \
@@ -63,6 +87,46 @@ JxlDecoder* getThreadDecoder() {
   }
   return decoder.get();
 }
+
+map<thread::id, JxlEncoderPtr>& getJxlEncoders() {
+  static map<thread::id, JxlEncoderPtr> sEncoders;
+  return sEncoders;
+}
+
+JxlEncoder* getThreadJxlEncoder() {
+  static mutex sMutex;
+  unique_lock<mutex> locker(sMutex);
+
+  auto& encoder = getJxlEncoders()[this_thread::get_id()];
+  if (encoder) {
+    JxlEncoderReset(encoder.get());
+  } else {
+    encoder = JxlEncoderMake(nullptr);
+  }
+  return encoder.get();
+}
+
+inline float percent_to_butteraugli_distance(float quality) {
+  // Quality calculation inspired by cjxl.cc
+  // Extended to work meaningfully between 99.99 and 99.999, so with quality = 99.999,
+  // the file size is now getting close to that of lossless.
+  // Improved continuity around the 26-30 range.
+  float butteraugli_distance;
+  if (quality >= 100) {
+    butteraugli_distance = 0;
+  } else if (quality >= 99.99) {
+    // linear, connecting to 100% <-> 0
+    butteraugli_distance = 0.0007 + (100 - quality) * 10;
+  } else if (quality >= 26.8) {
+    // linear, fairly soft changes
+    butteraugli_distance = 0.1 + (100 - quality) * 0.09;
+  } else {
+    // exponential, limit 15 max
+    butteraugli_distance = min<float>(15.f, 6.4 + pow(2.5, (30 - quality) / 5.0f) / 6.25f);
+  }
+  return butteraugli_distance;
+}
+
 } // namespace
 #endif
 
@@ -84,10 +148,10 @@ bool PixelFrame::readJxlFrame(RecordReader* reader, const uint32_t sizeBytes) {
 bool PixelFrame::readJxlFrame(const vector<uint8_t>& jxlBuf, bool decodePixels) {
 #ifdef JXL_IS_AVAILABLE
   auto dec = getThreadDecoder();
-  JXL_CHECK(JxlDecoderSubscribeEvents(
+  DEC_CHECK(JxlDecoderSubscribeEvents(
       dec, JXL_DEC_BASIC_INFO | JXL_DEC_COLOR_ENCODING | JXL_DEC_FULL_IMAGE));
 
-  JXL_CHECK(JxlDecoderSetInput(dec, jxlBuf.data(), jxlBuf.size()));
+  DEC_CHECK(JxlDecoderSetInput(dec, jxlBuf.data(), jxlBuf.size()));
   JxlDecoderCloseInput(dec);
 
   JxlPixelFormat format = {3, JXL_TYPE_UINT8, JXL_NATIVE_ENDIAN, 0 /* alignment */};
@@ -115,7 +179,7 @@ bool PixelFrame::readJxlFrame(const vector<uint8_t>& jxlBuf, bool decodePixels) 
 
       case JXL_DEC_BASIC_INFO: {
         JxlBasicInfo info = {};
-        JXL_CHECK(JxlDecoderGetBasicInfo(dec, &info));
+        DEC_CHECK(JxlDecoderGetBasicInfo(dec, &info));
         if (info.exponent_bits_per_sample != 0) {
           XR_LOGE("jxl floating point pixel format not supported (you can fix that)");
           return false;
@@ -158,7 +222,7 @@ bool PixelFrame::readJxlFrame(const vector<uint8_t>& jxlBuf, bool decodePixels) 
 
       case JXL_DEC_NEED_IMAGE_OUT_BUFFER: {
         size_t buffer_size;
-        JXL_CHECK(JxlDecoderImageOutBufferSize(dec, &format, &buffer_size));
+        DEC_CHECK(JxlDecoderImageOutBufferSize(dec, &format, &buffer_size));
         vector<uint8_t>& pixels = getBuffer();
         if (buffer_size != pixels.size()) {
           XR_LOGE(
@@ -167,12 +231,121 @@ bool PixelFrame::readJxlFrame(const vector<uint8_t>& jxlBuf, bool decodePixels) 
               pixels.size());
           return false;
         }
-        JXL_CHECK(JxlDecoderSetImageOutBuffer(dec, &format, pixels.data(), buffer_size));
+        DEC_CHECK(JxlDecoderSetImageOutBuffer(dec, &format, pixels.data(), buffer_size));
       } break;
 
       default:
         break;
     }
+  }
+  return true;
+#else
+  XR_LOGW_EVERY_N_SEC(10, "jpeg-xl support is not enabled.");
+  return false;
+#endif
+}
+
+bool PixelFrame::jxlCompress(
+    vector<uint8_t>& outBuffer,
+    float quality,
+    bool percentNotDistance,
+    int effort) {
+  return jxlCompress(imageSpec_, frameBytes_, outBuffer, quality, percentNotDistance, effort);
+}
+
+bool PixelFrame::jxlCompress(
+    const ImageContentBlockSpec& pixelSpec,
+    const vector<uint8_t>& pixels,
+    vector<uint8_t>& outBuffer,
+    float quality,
+    bool percentNotDistance,
+    int effort) {
+#ifdef JXL_IS_AVAILABLE
+  // Image quality, between 8.5 and 100 (lossless), with floating point resolution,
+  // so 99 is less than 99.5 which is less than 99.9, which is also less than 99.99.
+  // 99.995 is the best usable lossy quality setting, and 100 is a step jump to lossless.
+  // Sets the decoding speed tier for the provided options. Minimum is 0
+  // (slowest to decode, best quality/density), and maximum is 4 (fastest to
+  // decode, at the cost of some quality/density). Default is 0.
+  int decoding_speed_tier = 0;
+
+  const float butteraugli = percentNotDistance ? percent_to_butteraugli_distance(quality) : quality;
+
+  JxlEncoder* enc = getThreadJxlEncoder();
+
+  const uint32_t channels = pixelSpec.getChannelCountPerPixel();
+
+  JxlPixelFormat pixel_format = {channels, JXL_TYPE_UINT8, JXL_NATIVE_ENDIAN, 0};
+
+  JxlBasicInfo basic_info = {};
+  JxlEncoderInitBasicInfo(&basic_info); // Default set to RGB8
+  basic_info.xsize = pixelSpec.getWidth();
+  basic_info.ysize = pixelSpec.getHeight();
+  basic_info.num_color_channels = channels;
+  switch (pixelSpec.getPixelFormat()) {
+    case PixelFormat::GREY8:
+    case PixelFormat::RGB8:
+      basic_info.bits_per_sample = 8;
+      pixel_format.data_type = JXL_TYPE_UINT8;
+      break;
+
+    default:
+      return false; // Should have been rejected by canConvert()
+  }
+  basic_info.uses_original_profile = (butteraugli <= 0) ? JXL_TRUE : JXL_FALSE;
+
+  ENC_CHECK(JxlEncoderSetBasicInfo(enc, &basic_info));
+
+  JxlColorEncoding color_encoding = {};
+  JxlColorEncodingSetToSRGB(
+      &color_encoding,
+      /*is_gray=*/pixel_format.num_channels < 3);
+  ENC_CHECK(JxlEncoderSetColorEncoding(enc, &color_encoding));
+
+  auto settings = JxlEncoderFrameSettingsCreate(enc, nullptr);
+  ENC_CHECK(JxlEncoderFrameSettingsSetOption(settings, JXL_ENC_FRAME_SETTING_EFFORT, effort));
+  ENC_CHECK(JxlEncoderFrameSettingsSetOption(
+      settings, JXL_ENC_FRAME_SETTING_DECODING_SPEED, decoding_speed_tier));
+#if 0
+    // code to tune quality to butteraugli_distance conversion
+    float last = 0;
+    for (quality = 99.985; quality < 100; quality += 0.0001) {
+      float butteraugli_distance = percent_to_butteraugli_distance(quality);
+      ENC_CHECK(JxlEncoderSetFrameDistance(settings, butteraugli_distance));
+      fmt::print(
+          "Quality: {} Distance: {} Gap: {}\n",
+          quality,
+          butteraugli_distance,
+          last - butteraugli_distance);
+      last = butteraugli_distance;
+    }
+#endif
+  if (butteraugli <= 0) {
+    ENC_CHECK(JxlEncoderSetFrameLossless(settings, JXL_TRUE));
+  } else {
+    ENC_CHECK(JxlEncoderSetFrameDistance(settings, butteraugli));
+  }
+  ENC_CHECK(JxlEncoderAddImageFrame(settings, &pixel_format, pixels.data(), pixels.size()));
+  JxlEncoderCloseInput(enc);
+
+  static atomic<size_t> sStartSize{256 * 1024}; // shared between threads
+  size_t allocSize = sStartSize.load(memory_order_relaxed);
+  helpers::MemBuffer memBuffer(allocSize);
+
+  uint8_t* outData{};
+  JxlEncoderStatus encoderStatus;
+  do {
+    size_t allocatedSize = memBuffer.allocateSpace(outData, allocSize / 5);
+    size_t remainingSize = allocatedSize;
+    encoderStatus = JxlEncoderProcessOutput(enc, &outData, &remainingSize);
+    if (JXL_ENC_SUCCESS != encoderStatus && JXL_ENC_NEED_MORE_OUTPUT != encoderStatus) {
+      throw runtime_error("JxlEncoderProcessOutput failed");
+    }
+    memBuffer.addAllocatedSpace(allocatedSize - remainingSize);
+  } while (encoderStatus == JXL_ENC_NEED_MORE_OUTPUT);
+  memBuffer.getData(outBuffer);
+  if (outBuffer.size() > sStartSize.load(memory_order_relaxed)) {
+    sStartSize.store(outBuffer.size() + outBuffer.size() / 100, memory_order_relaxed);
   }
   return true;
 #else


### PR DESCRIPTION
Summary: This diff groups image jxl encoding functionality from unit test to PixelFrame, for reuse.

Differential Revision: D39790559

