### PR TITLE
Downgrade the ubuntu version in github action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest,  macOS-latest]
+        os: [ubuntu-20.04,  macOS-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-20.04, macos-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:

--- a/.github/workflows/publish-test-python-package.yml
+++ b/.github/workflows/publish-test-python-package.yml
@@ -56,7 +56,7 @@ jobs:
       PYVRS_TEST_BUILD: 1
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
@@ -98,7 +98,7 @@ jobs:
     needs:
     - build-bin-macos
     - build-bin-linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Download all the dists

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build_docs_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.6]


### PR DESCRIPTION
Summary:
Github actions start to fail recently on Ubuntu env while we haven't touched anything except for move -> std::move diffs.
According to https://github.com/actions/runner-images/pull/6674/files ubuntu-latest now points to ubuntu-22.04 while last successful run uses 20.04.

Trying to see if this is the problem.

Differential Revision: D41716793

