### PR TITLE
Fix python package publish logic to test.pypi.org

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,16 +1,14 @@
 name: Publish Python package to test.pypi.org
 
 on:
-  # run every day at 1am
+  # run every day at 2:30 PST
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '30 10 * * *'
 
 jobs:
   build-bin-macos:
     if: github.repository == 'facebookresearch/vrs'
     runs-on: ${{ matrix.os }}
-    env:
-      PYVRS_TEST_BUILD: 1
     strategy:
       matrix:
         os: [macos-latest]
@@ -52,8 +50,6 @@ jobs:
   build-bin-linux:
     if: github.repository == 'facebookresearch/vrs'
     runs-on: ${{ matrix.os }}
-    env:
-      PYVRS_TEST_BUILD: 1
     strategy:
       matrix:
         os: [ubuntu-20.04]
@@ -106,7 +102,6 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
-      # While setting up the workflow push to test.pypi.org instead of pypi.org
       - name: Deploy to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/pyvrs/setup.py
+++ b/pyvrs/setup.py
@@ -114,7 +114,7 @@ def main():
         long_description = f.read()
 
     setup(
-        name="pyvrs",
+        name="vrs",
         version=get_version(),
         description="Python API for VRS",
         long_description=long_description,


### PR DESCRIPTION
Summary:
According to the error message and pypi website, it turns out that test.pypi.org doesn't accept the version form <major>.<minor>.<patch>+<hash>.
Reviewing other internal repository, they are also stripping the hash part.
In this diff, we remove the environmental var used to add the hash to the version number.

Differential Revision: D41758935

