### PR TITLE
Change distribution name to vrs instead of pyvrs

### DIFF
--- a/pyvrs/setup.py
+++ b/pyvrs/setup.py
@@ -114,7 +114,7 @@ def main():
         long_description = f.read()
 
     setup(
-        name="pyvrs",
+        name="vrs",
         version=get_version(),
         description="Python API for VRS",
         long_description=long_description,


### PR DESCRIPTION
Summary:
The pypi package name pyvrs is already taken but vrs is not taken.
Use vrs as a distribution name so that we can install with `pip install vrs`

Reviewed By: matt-fff

Differential Revision: D41842635

