### PR TITLE
Enforce const semantics for DataLayout::findDataPieceStringMap()

### DIFF
--- a/vrs/DataLayout.cpp
+++ b/vrs/DataLayout.cpp
@@ -503,7 +503,7 @@ static DataPieceFactory::Registerer<DataPieceStringMap<string>> Registerer_DataP
 } // namespace internal
 
 template <typename T>
-DataPieceValue<T>* DataLayout::findDataPieceValue(const string& label) const {
+const DataPieceValue<T>* DataLayout::findDataPieceValue(const string& label) const {
   const string& typeName = vrs::getTypeName<T>();
   for (DataPiece* piece : fixedSizePieces_) {
     if (piece->getPieceType() == DataPieceType::Value && piece->getLabel() == label &&
@@ -515,7 +515,14 @@ DataPieceValue<T>* DataLayout::findDataPieceValue(const string& label) const {
 }
 
 template <typename T>
-DataPieceArray<T>* DataLayout::findDataPieceArray(const string& label, size_t arraySize) const {
+DataPieceValue<T>* DataLayout::findDataPieceValue(const string& label) {
+  return const_cast<DataPieceValue<T>*>(
+      const_cast<const DataLayout*>(this)->findDataPieceValue<T>(label));
+}
+
+template <typename T>
+const DataPieceArray<T>* DataLayout::findDataPieceArray(const string& label, size_t arraySize)
+    const {
   const string& typeName = vrs::getTypeName<T>();
   size_t size = arraySize * sizeof(T);
   for (DataPiece* piece : fixedSizePieces_) {
@@ -528,7 +535,13 @@ DataPieceArray<T>* DataLayout::findDataPieceArray(const string& label, size_t ar
 }
 
 template <typename T>
-DataPieceVector<T>* DataLayout::findDataPieceVector(const string& label) const {
+DataPieceArray<T>* DataLayout::findDataPieceArray(const string& label, size_t arraySize) {
+  return const_cast<DataPieceArray<T>*>(
+      const_cast<const DataLayout*>(this)->findDataPieceArray<T>(label, arraySize));
+}
+
+template <typename T>
+const DataPieceVector<T>* DataLayout::findDataPieceVector(const string& label) const {
   const string& typeName = vrs::getTypeName<T>();
   for (DataPiece* piece : varSizePieces_) {
     if (piece->getPieceType() == DataPieceType::Vector && piece->getLabel() == label &&
@@ -539,11 +552,18 @@ DataPieceVector<T>* DataLayout::findDataPieceVector(const string& label) const {
   return nullptr;
 }
 
-template DataPieceVector<string>* DataLayout::findDataPieceVector<string>(
+template <typename T>
+DataPieceVector<T>* DataLayout::findDataPieceVector(const string& label) {
+  return const_cast<DataPieceVector<T>*>(
+      const_cast<const DataLayout*>(this)->findDataPieceVector<T>(label));
+}
+
+template const DataPieceVector<string>* DataLayout::findDataPieceVector<string>(
     const string& label) const;
+template DataPieceVector<string>* DataLayout::findDataPieceVector<string>(const string& label);
 
 template <typename T>
-DataPieceStringMap<T>* DataLayout::findDataPieceStringMap(const string& label) const {
+const DataPieceStringMap<T>* DataLayout::findDataPieceStringMap(const string& label) const {
   const string& typeName = vrs::getTypeName<T>();
   for (DataPiece* piece : varSizePieces_) {
     if (piece->getPieceType() == DataPieceType::StringMap && piece->getLabel() == label &&
@@ -554,16 +574,29 @@ DataPieceStringMap<T>* DataLayout::findDataPieceStringMap(const string& label) c
   return nullptr;
 }
 
-template DataPieceStringMap<string>* DataLayout::findDataPieceStringMap<string>(
-    const string& label) const;
+template <typename T>
+DataPieceStringMap<T>* DataLayout::findDataPieceStringMap(const string& label) {
+  return const_cast<DataPieceStringMap<T>*>(
+      const_cast<const DataLayout*>(this)->findDataPieceStringMap<T>(label));
+}
 
-DataPieceString* DataLayout::findDataPieceString(const string& label) const {
+template const DataPieceStringMap<string>* DataLayout::findDataPieceStringMap<string>(
+    const string& label) const;
+template DataPieceStringMap<string>* DataLayout::findDataPieceStringMap<string>(
+    const string& label);
+
+const DataPieceString* DataLayout::findDataPieceString(const string& label) const {
   for (DataPiece* piece : varSizePieces_) {
     if (piece->getPieceType() == DataPieceType::String && piece->getLabel() == label) {
       return static_cast<DataPieceString*>(piece);
     }
   }
   return nullptr;
+}
+
+DataPieceString* DataLayout::findDataPieceString(const string& label) {
+  return const_cast<DataPieceString*>(
+      const_cast<const DataLayout*>(this)->findDataPieceString(label));
 }
 
 void DataLayout::forEachDataPiece(function<void(const DataPiece*)> callback, DataPieceType type)
@@ -693,12 +726,18 @@ size_t DataLayout::getAvailableVarDataPiecesCount() const {
   return count;
 }
 
-#define DEFINE_FIND_DATA_PIECE(T)                                                           \
-  template DataPieceValue<T>* DataLayout::findDataPieceValue<T>(const string& label) const; \
-  template DataPieceArray<T>* DataLayout::findDataPieceArray(                               \
-      const string& label, size_t arraySize) const;                                         \
-  template DataPieceVector<T>* DataLayout::findDataPieceVector(const string& label) const;  \
-  template DataPieceStringMap<T>* DataLayout::findDataPieceStringMap(const string& label) const;
+#define DEFINE_FIND_DATA_PIECE(T)                                                                 \
+  template const DataPieceValue<T>* DataLayout::findDataPieceValue<T>(const string& label) const; \
+  template DataPieceValue<T>* DataLayout::findDataPieceValue<T>(const string& label);             \
+  template const DataPieceArray<T>* DataLayout::findDataPieceArray(                               \
+      const string& label, size_t arraySize) const;                                               \
+  template DataPieceArray<T>* DataLayout::findDataPieceArray(                                     \
+      const string& label, size_t arraySize);                                                     \
+  template const DataPieceVector<T>* DataLayout::findDataPieceVector(const string& label) const;  \
+  template DataPieceVector<T>* DataLayout::findDataPieceVector(const string& label);              \
+  template const DataPieceStringMap<T>* DataLayout::findDataPieceStringMap(const string& label)   \
+      const;                                                                                      \
+  template DataPieceStringMap<T>* DataLayout::findDataPieceStringMap(const string& label);
 
 #define DEFINE_DATA_PIECE_TYPE(x)          \
   template <>                              \

--- a/vrs/DataLayout.h
+++ b/vrs/DataLayout.h
@@ -356,30 +356,39 @@ class DataLayout {
   /// @return Pointer to the DataPiece found, or nullptr.
   /// @internal (meant for testing)
   template <class T>
-  DataPieceValue<T>* findDataPieceValue(const string& label) const;
+  const DataPieceValue<T>* findDataPieceValue(const string& label) const;
+  template <class T>
+  DataPieceValue<T>* findDataPieceValue(const string& label);
   /// Find a field of type DataPieceArray<T> by name.
   /// @param label: Text name of the field (not the variable name).
   /// @return Pointer to the DataPiece found, or nullptr.
   /// @internal (meant for testing)
   template <class T>
-  DataPieceArray<T>* findDataPieceArray(const string& label, size_t arraySize) const;
+  const DataPieceArray<T>* findDataPieceArray(const string& label, size_t arraySize) const;
+  template <class T>
+  DataPieceArray<T>* findDataPieceArray(const string& label, size_t arraySize);
   /// Find a field of type DataPieceVector<T> by name.
   /// @param label: Text name of the field (not the variable name).
   /// @return Pointer to the DataPiece found, or nullptr.
   /// @internal (meant for testing)
   template <class T>
-  DataPieceVector<T>* findDataPieceVector(const string& label) const;
+  const DataPieceVector<T>* findDataPieceVector(const string& label) const;
+  template <class T>
+  DataPieceVector<T>* findDataPieceVector(const string& label);
   /// Find a field of type DataPieceStringMap<T> by name.
   /// @param label: Text name of the field (not the variable name).
   /// @return Pointer to the DataPiece found, or nullptr.
   /// @internal (meant for testing)
   template <class T>
-  DataPieceStringMap<T>* findDataPieceStringMap(const string& label) const;
+  const DataPieceStringMap<T>* findDataPieceStringMap(const string& label) const;
+  template <class T>
+  DataPieceStringMap<T>* findDataPieceStringMap(const string& label);
   /// Find a field of type DataPieceString by name.
   /// @param label: Text name of the field (not the variable name).
   /// @return Pointer to the DataPiece found, or nullptr.
   /// @internal (meant for testing)
-  DataPieceString* findDataPieceString(const string& label) const;
+  const DataPieceString* findDataPieceString(const string& label) const;
+  DataPieceString* findDataPieceString(const string& label);
   /// Iterate over the different data piece elements of a DataLayout.
   /// @param callback: a function to call for each element found.
   /// @param type: filter to select only an element type, of UNDEFINED for no filtering.

--- a/vrs/test/DataLayoutTest.cpp
+++ b/vrs/test/DataLayoutTest.cpp
@@ -786,18 +786,23 @@ struct MetadataTest : public AutoDataLayout {
   }
   DataPieceValue<int32_t> intValue{"int"};
   DataPieceValue<float> floatValue{"float"};
+  DataPieceArray<float> floatArrayValue{"float_array", 2};
+  DataPieceVector<float> floatVectorValue{"float_vector"};
+  DataPieceStringMap<uint8_t> uintStringMapValue{"uint_string_map"};
+  DataPieceString stringValue{"string"};
 
   AutoDataLayoutEnd end;
 };
 } // namespace
 
 TEST_F(DataLayoutTester, testMetaData) {
-  MetadataTest data;
-  string js = data.asJson(JsonFormatProfile::VrsFormat);
+  const MetadataTest data;
+  const string js = data.asJson(JsonFormatProfile::VrsFormat);
   unique_ptr<DataLayout> dl = DataLayout::makeFromJson(js);
   ASSERT_NE(dl, nullptr);
   EXPECT_TRUE(data.isSame(*dl));
-  DataPieceValue<int32_t>* intValue = dl->findDataPieceValue<int32_t>("int");
+
+  const DataPieceValue<int32_t>* intValue = dl->findDataPieceValue<int32_t>("int");
   ASSERT_NE(intValue, nullptr);
   int32_t v;
   EXPECT_TRUE(intValue->getMin(v));
@@ -813,13 +818,27 @@ TEST_F(DataLayoutTester, testMetaData) {
   EXPECT_STREQ(s.c_str(), "meter");
   EXPECT_TRUE(intValue->getDescription(s));
   EXPECT_STREQ(s.c_str(), "some int");
-  DataPieceValue<float>* floatValue = dl->findDataPieceValue<float>("float");
+
+  const DataPieceValue<float>* floatValue = dl->findDataPieceValue<float>("float");
   ASSERT_NE(floatValue, nullptr);
   float f;
   EXPECT_TRUE(floatValue->getMin(f));
   EXPECT_NEAR(f, -10.f, 0.0001f);
   EXPECT_TRUE(floatValue->getMax(f));
   EXPECT_NEAR(f, 100.f, 0.0001f);
+
+  const DataPieceArray<float>* floatArrayValue = dl->findDataPieceArray<float>("float_array", 2);
+  ASSERT_NE(floatArrayValue, nullptr);
+
+  const DataPieceVector<float>* floatVectorValue = dl->findDataPieceVector<float>("float_vector");
+  ASSERT_NE(floatVectorValue, nullptr);
+
+  const DataPieceStringMap<uint8_t>* stringMapValue =
+      dl->findDataPieceStringMap<uint8_t>("uint_string_map");
+  ASSERT_NE(stringMapValue, nullptr);
+
+  const DataPieceString* stringValue = dl->findDataPieceString("string");
+  ASSERT_NE(stringValue, nullptr);
 }
 
 TEST_F(DataLayoutTester, testStaging) {


### PR DESCRIPTION
Summary:
DataLayout's `findDataPiece*()` methods are all marked `const` but return non-`const` `DataPiece*` pointers. This breaks the expected semantics as you could then modify the data even though you retrieved it from a `const` container. This fixes it by updating the `const` version to return a pointer to `const` and adding a non-`const` version that works like before.

Also added some logic to test these accessors to an existing unit test as they didn't have good coverage.

Reviewed By: georges-berenger

Differential Revision: D37195636

