### PR TITLE
Options to make overlay text more readable

### DIFF
--- a/tools/vrsplayer/FileReader.cpp
+++ b/tools/vrsplayer/FileReader.cpp
@@ -413,6 +413,18 @@ void FileReader::setOverlayColor(QColor color) {
   }
 }
 
+void FileReader::setFontSize(int fontSize) {
+  for (auto& image : imageReaders_) {
+    image.second->getWidget()->setFontSize(fontSize);
+  }
+}
+
+void FileReader::setSolidBackground(bool solid) {
+  for (auto& image : imageReaders_) {
+    image.second->getWidget()->setSolidBackground(solid);
+  }
+}
+
 void FileReader::recordTypeChanged(const QString& type) {
   recordType_ = toEnum<Record::Type>(type.toStdString());
   for (auto& image : imageReaders_) {

--- a/tools/vrsplayer/FileReader.h
+++ b/tools/vrsplayer/FileReader.h
@@ -122,6 +122,8 @@ class FileReader : public QObject {
  public slots:
   std::vector<FrameWidget*> openFile(const QString& url, QVBoxLayout* videoFrame, QWidget* parent);
   void setOverlayColor(QColor color);
+  void setFontSize(int fontSize);
+  void setSolidBackground(bool solid);
   void recordTypeChanged(const QString& type);
   void setPosition(int position);
   void sliderPressed();

--- a/tools/vrsplayer/FrameWidget.h
+++ b/tools/vrsplayer/FrameWidget.h
@@ -127,6 +127,14 @@ class FrameWidget : public QWidget {
     overlayColor_ = color;
     setNeedsUpdate();
   }
+  void setFontSize(int fontSize) {
+    fontSize_ = fontSize;
+    setNeedsUpdate();
+  }
+  void setSolidBackground(bool solid) {
+    solidBackground_ = solid;
+    setNeedsUpdate();
+  }
   void blank();
   void updateMinMaxSize();
 
@@ -153,6 +161,8 @@ class FrameWidget : public QWidget {
   Fps imageFps_;
   Fps drawFps_;
   QColor overlayColor_{Qt::yellow};
+  int fontSize_{14};
+  bool solidBackground_{false};
   int rotation_{0};
   bool flipped_{false};
   bool hasFrame_{false};

--- a/tools/vrsplayer/PlayerUI.cpp
+++ b/tools/vrsplayer/PlayerUI.cpp
@@ -41,6 +41,8 @@ const double kDefaultScreenOccupationRatio = 0.8; // use most of the screen (arb
 const QString kLastFilePathSetting("last_file_path");
 const QString kLastRecordTypeSetting("last_record_type");
 const QString kOverlayColorSetting("overlay_color");
+const QString kOverlayFontSizeSetting("overlay_font_size");
+const QString kOverlaySolidBackgroundSetting("overlay_solid_background");
 
 const QString kDefaultSpeed("1x");
 
@@ -275,6 +277,15 @@ void PlayerUI::openPath(const QString& path) {
   if (overlayColor.isValid()) {
     setOverlayColor(overlayColor.value<QColor>());
   }
+  QVariant fontSize = settings_.value(kOverlayFontSizeSetting);
+  if (fontSize.isValid()) {
+    fontSize_ = fontSize.value<int>();
+    adjustOverlayFontSize(0);
+  }
+  QVariant solidBackground = settings_.value(kOverlaySolidBackgroundSetting);
+  if (solidBackground.isValid()) {
+    setSolidBackground(solidBackground.value<bool>());
+  }
   resizeIfNecessary();
 }
 
@@ -397,8 +408,32 @@ void PlayerUI::reportError(QString errorTitle, QString errorMessage) {
 }
 
 void PlayerUI::setOverlayColor(QColor color) {
-  fileReader_.setOverlayColor(color);
-  settings_.setValue(kOverlayColorSetting, color);
+  overlayColor_ = color;
+  fileReader_.setOverlayColor(overlayColor_);
+  settings_.setValue(kOverlayColorSetting, overlayColor_);
+  overlaySettingChanged();
+}
+
+void PlayerUI::adjustOverlayFontSize(int sizeChange) {
+  const int kDefaultFontSize = 14;
+  const int kMinFontSize = 7;
+  const int kMaxFontSize = 50;
+  fontSize_ += sizeChange;
+  if (fontSize_ == 0) {
+    fontSize_ = kDefaultFontSize;
+  }
+  fontSize_ = max<int>(fontSize_, kMinFontSize);
+  fontSize_ = min<int>(fontSize_, kMaxFontSize);
+  fileReader_.setFontSize(fontSize_);
+  settings_.setValue(kOverlayFontSizeSetting, fontSize_);
+  overlaySettingChanged();
+}
+
+void PlayerUI::setSolidBackground(bool solid) {
+  solidBackground_ = solid;
+  fileReader_.setSolidBackground(solidBackground_);
+  settings_.setValue(kOverlaySolidBackgroundSetting, solidBackground_);
+  overlaySettingChanged();
 }
 
 void PlayerUI::adjustSpeed(int change) {

--- a/tools/vrsplayer/PlayerUI.h
+++ b/tools/vrsplayer/PlayerUI.h
@@ -20,8 +20,10 @@
 #include <vector>
 
 #include <QtCore/qglobal.h>
+#include <qcolor.h>
 #include <qcombobox.h>
 #include <qgraphicsscene.h>
+#include <qnamespace.h>
 #include <qpixmap.h>
 #include <qsettings.h>
 #include <qwidget.h>
@@ -57,6 +59,7 @@ class PlayerUI : public QWidget {
   }
 
  signals:
+  void overlaySettingChanged();
 
  public slots:
   void openFileChooser();
@@ -77,6 +80,14 @@ class PlayerUI : public QWidget {
   void deletePreset(const QString& preset);
   void reportError(QString errorTitle, QString errorMessage);
   void setOverlayColor(QColor color);
+  QColor getOverlayColor() const {
+    return overlayColor_;
+  }
+  void adjustOverlayFontSize(int sizeChange);
+  void setSolidBackground(bool solid);
+  bool isSolidBackground() const {
+    return solidBackground_;
+  }
   void adjustSpeed(int change);
 
  private slots:
@@ -90,6 +101,9 @@ class PlayerUI : public QWidget {
 
  private:
   QSettings settings_;
+  QColor overlayColor_{Qt::yellow};
+  int fontSize_{14};
+  bool solidBackground_{false};
   FileReader fileReader_;
   QVBoxLayout* videoFrames_;
   std::vector<FrameWidget*> frames_;

--- a/tools/vrsplayer/PlayerWindow.cpp
+++ b/tools/vrsplayer/PlayerWindow.cpp
@@ -36,6 +36,7 @@ PlayerWindow::PlayerWindow(QApplication& app) : QMainWindow(nullptr) {
       &FileReader::updateLayoutMenu,
       this,
       &PlayerWindow::updateLayoutMenu);
+  connect(&player_, &PlayerUI ::overlaySettingChanged, this, &PlayerWindow::updateTextOverlayMenu);
   setWindowFlags(windowFlags() | Qt::CustomizeWindowHint | Qt::WindowMinMaxButtonsHint);
 }
 
@@ -97,31 +98,8 @@ void PlayerWindow::createMenus() {
   fileMenu_->addAction(aboutAction);
 #endif
 
-  colorMenu_ = menuBar()->addMenu("Text Color");
-  QAction* white = new QAction("Use White", this);
-  connect(white, &QAction::triggered, [this]() { player_.setOverlayColor(Qt::white); });
-  colorMenu_->addAction(white);
-  QAction* black = new QAction("Use Black", this);
-  connect(black, &QAction::triggered, [this]() { player_.setOverlayColor(Qt::black); });
-  colorMenu_->addAction(black);
-  QAction* green = new QAction("Use Green", this);
-  connect(green, &QAction::triggered, [this]() { player_.setOverlayColor(Qt::green); });
-  colorMenu_->addAction(green);
-  QAction* red = new QAction("Use Red", this);
-  connect(red, &QAction::triggered, [this]() { player_.setOverlayColor(Qt::red); });
-  colorMenu_->addAction(red);
-  QAction* blue = new QAction("Use Blue", this);
-  connect(blue, &QAction::triggered, [this]() { player_.setOverlayColor(Qt::blue); });
-  colorMenu_->addAction(blue);
-  QAction* yellow = new QAction("Use Yellow", this);
-  connect(yellow, &QAction::triggered, [this]() { player_.setOverlayColor(Qt::yellow); });
-  colorMenu_->addAction(yellow);
-  QAction* cyan = new QAction("Use Cyan", this);
-  connect(cyan, &QAction::triggered, [this]() { player_.setOverlayColor(Qt::cyan); });
-  colorMenu_->addAction(cyan);
-  QAction* magenta = new QAction("Use Magenta", this);
-  connect(magenta, &QAction::triggered, [this]() { player_.setOverlayColor(Qt::magenta); });
-  colorMenu_->addAction(magenta);
+  textOverlayMenu_ = menuBar()->addMenu("Text Overlay");
+  updateTextOverlayMenu();
 
   layoutMenu_ = menuBar()->addMenu("Layout");
 
@@ -204,4 +182,43 @@ void PlayerWindow::updateLayoutMenu(
     layoutMenu_->addAction(layoutAction.get());
     layoutActions_.emplace_back(std::move(layoutAction));
   }
+}
+
+void PlayerWindow::updateTextOverlayMenu() {
+  textOverlayMenu_->clear();
+  QColor color = player_.getOverlayColor();
+  addColorAction(color, Qt::white, "Use White");
+  addColorAction(color, Qt::black, "Use Black");
+  addColorAction(color, Qt::green, "Use Green");
+  addColorAction(color, Qt::red, "Use Red");
+  addColorAction(color, Qt::blue, "Use Blue");
+  addColorAction(color, Qt::yellow, "Use Yellow");
+  addColorAction(color, Qt::cyan, "Use Cyan");
+  addColorAction(color, Qt::magenta, "Use Magenta");
+  textOverlayMenu_->addSeparator();
+  QAction* smallerFont = new QAction("Smaller Font", this);
+  smallerFont->setShortcut(Qt::CTRL | Qt::Key_Minus);
+  connect(smallerFont, &QAction::triggered, [this]() { player_.adjustOverlayFontSize(-1); });
+  textOverlayMenu_->addAction(smallerFont);
+  QAction* largetFont = new QAction("Larger Font", this);
+  largetFont->setShortcut(Qt::CTRL | Qt::Key_Plus);
+  connect(largetFont, &QAction::triggered, [this]() { player_.adjustOverlayFontSize(+1); });
+  textOverlayMenu_->addAction(largetFont);
+  textOverlayMenu_->addSeparator();
+  bool isSolid = player_.isSolidBackground();
+  QAction* solidBackground = new QAction("Solid Background", this);
+  connect(solidBackground, &QAction::triggered, [this, isSolid]() {
+    player_.setSolidBackground(!isSolid);
+  });
+  solidBackground->setCheckable(true);
+  solidBackground->setChecked(isSolid);
+  textOverlayMenu_->addAction(solidBackground);
+}
+
+void PlayerWindow::addColorAction(const QColor& overlay, const QColor& color, const char* cmdName) {
+  QAction* action = new QAction(cmdName, this);
+  connect(action, &QAction::triggered, [this, color]() { player_.setOverlayColor(color); });
+  action->setCheckable(true);
+  action->setChecked(overlay == color);
+  textOverlayMenu_->addAction(action);
 }

--- a/tools/vrsplayer/PlayerWindow.h
+++ b/tools/vrsplayer/PlayerWindow.h
@@ -53,13 +53,17 @@ class PlayerWindow : public QMainWindow {
       int maxPerRowCount,
       const QVariantMap& presets,
       const QVariant& currentPreset);
+  void updateTextOverlayMenu();
+
+ private:
+  void addColorAction(const QColor& overlay, const QColor& color, const char* cmdName);
 
  private:
   PlayerUI player_;
   QMenu* fileMenu_;
   QMenu* layoutMenu_;
   QMenu* orientationMenu_;
-  QMenu* colorMenu_;
+  QMenu* textOverlayMenu_;
   std::vector<std::unique_ptr<QAction>> layoutActions_;
 };
 


### PR DESCRIPTION
Summary:
The text overlay over images can be difficult to read...
- give option to make the text larger/smaller, with keyboard shortcuts (cmd-'+' and cmd-'-' like with a browsser.
- give option to write text over a solid background.

Differential Revision: D42256761

