### PR TITLE
Fix open source build

### DIFF
--- a/vrs/utils/PixelFrameJxl.cpp
+++ b/vrs/utils/PixelFrameJxl.cpp
@@ -15,8 +15,6 @@
  */
 
 #include "PixelFrame.h"
-#include "jxl/decode.h"
-#include "jxl/encode.h"
 
 #include <algorithm>
 #include <map>


### PR DESCRIPTION
Summary: These unecessary includes were added for no reason, and broke the build.

Differential Revision: D43112376

