### PR TITLE
Use std::tie to make multi-field comparisons

### DIFF
--- a/vrs/FileSpec.cpp
+++ b/vrs/FileSpec.cpp
@@ -17,8 +17,10 @@
 #include "FileHandler.h"
 
 #include <cstring>
+
 #include <iostream>
 #include <sstream>
+#include <tuple>
 
 #define DEFAULT_LOG_CHANNEL "FileHandler"
 #include <logging/Log.h>
@@ -339,8 +341,10 @@ string FileSpec::getXXHash() const {
 }
 
 bool FileSpec::operator==(const FileSpec& rhs) const {
-  return fileName == rhs.fileName && fileHandlerName == rhs.fileHandlerName && uri == rhs.uri &&
-      chunks == rhs.chunks && chunkSizes == rhs.chunkSizes && extras == rhs.extras;
+  auto tie = [](const FileSpec& fs) {
+    return std::tie(fs.fileName, fs.fileHandlerName, fs.uri, fs.chunks, fs.chunkSizes, fs.extras);
+  };
+  return tie(*this) == tie(rhs);
 }
 
 string FileSpec::getExtra(const string& name) const {

--- a/vrs/IndexRecord.h
+++ b/vrs/IndexRecord.h
@@ -18,6 +18,7 @@
 
 #include <deque>
 #include <set>
+#include <tuple>
 
 #include "Compressor.h"
 #include "DiskFile.h"
@@ -113,15 +114,17 @@ struct RecordInfo {
   Record::Type recordType; ///< type of record
 
   bool operator<(const RecordInfo& rhs) const {
-    return this->timestamp < rhs.timestamp ||
-        (this->timestamp <= rhs.timestamp &&
-         (this->streamId < rhs.streamId ||
-          (this->streamId == rhs.streamId && this->fileOffset < rhs.fileOffset)));
+    auto tie = [](const RecordInfo& ri) {
+      return std::tie(ri.timestamp, ri.streamId, ri.fileOffset);
+    };
+    return tie(*this) < tie(rhs);
   }
 
   bool operator==(const RecordInfo& rhs) const {
-    return this->timestamp == rhs.timestamp && this->fileOffset == rhs.fileOffset &&
-        this->streamId == rhs.streamId && this->recordType == rhs.recordType;
+    auto tie = [](const RecordInfo& ri) {
+      return std::tie(ri.timestamp, ri.fileOffset, ri.streamId, ri.recordType);
+    };
+    return tie(*this) == tie(rhs);
   }
 };
 
@@ -240,8 +243,10 @@ struct RecordSignature {
   Record::Type recordType;
 
   bool operator<(const RecordSignature& rhs) const {
-    return this->recordType < rhs.recordType ||
-        (this->recordType == rhs.recordType && this->streamId < rhs.streamId);
+    auto tie = [](const RecordSignature& recordSignature) {
+      return std::tie(recordSignature.recordType, recordSignature.streamId);
+    };
+    return tie(*this) < tie(rhs);
   }
 };
 

--- a/vrs/Record.h
+++ b/vrs/Record.h
@@ -121,11 +121,11 @@ class Record final {
       uint32_t compressedSize);
 
   /// Get the record's timestamp.
-  double getTimestamp() const {
+  const double& getTimestamp() const {
     return timestamp_;
   }
 
-  uint64_t getCreationOrder() const {
+  const uint64_t& getCreationOrder() const {
     return creationOrder_;
   }
 

--- a/vrs/RecordFormat.h
+++ b/vrs/RecordFormat.h
@@ -364,17 +364,21 @@ class AudioContentBlockSpec {
 
   /// Compare two audio block spec.
   bool operator==(const AudioContentBlockSpec& rhs) const {
-    return sampleFormat_ == rhs.sampleFormat_ && channelCount_ == rhs.channelCount_ &&
-        sampleBlockStride_ == rhs.sampleBlockStride_ && sampleCount_ == rhs.sampleCount_ &&
-        sampleRate_ == rhs.sampleRate_;
+    auto tie = [](const AudioContentBlockSpec& s) {
+      return std::tie(
+          s.sampleFormat_, s.channelCount_, s.sampleBlockStride_, s.sampleCount_, s.sampleRate_);
+    };
+    return tie(*this) == tie(rhs);
   }
   bool operator!=(const AudioContentBlockSpec& rhs) const {
     return !operator==(rhs);
   }
   /// Tell if two audio block have identical audio formats.
   bool isCompatibleWith(const AudioContentBlockSpec& rhs) const {
-    return sampleFormat_ == rhs.sampleFormat_ && channelCount_ == rhs.channelCount_ &&
-        sampleRate_ == rhs.sampleRate_;
+    auto tie = [](const AudioContentBlockSpec& s) {
+      return std::tie(s.sampleFormat_, s.channelCount_, s.sampleRate_);
+    };
+    return tie(*this) == tie(rhs);
   }
   /// Get audio format.
   AudioFormat getAudioFormat() const {

--- a/vrs/StreamId.h
+++ b/vrs/StreamId.h
@@ -17,7 +17,9 @@
 #pragma once
 
 #include <cstdint>
+
 #include <string>
+#include <tuple>
 
 #include <vrs/os/Platform.h>
 
@@ -246,7 +248,8 @@ class StreamId {
 
   /// Compare operator, so that we can use StreamId in containers, with a guarantied behavior.
   bool operator<(const StreamId& rhs) const {
-    return typeId_ < rhs.typeId_ || (typeId_ == rhs.typeId_ && instanceId_ < rhs.instanceId_);
+    auto tie = [](const StreamId& id) { return std::tie(id.typeId_, id.instanceId_); };
+    return tie(*this) < tie(rhs);
   }
 
   /// Test if the instance represents device.

--- a/vrs/TelemetryLogger.h
+++ b/vrs/TelemetryLogger.h
@@ -38,8 +38,8 @@ struct OperationContext {
       : operation{std::move(rhs.operation)}, sourceLocation{std::move(rhs.sourceLocation)} {}
 
   bool operator<(const OperationContext& rhs) const {
-    return operation < rhs.operation ||
-        (operation == rhs.operation && sourceLocation < rhs.sourceLocation);
+    auto tie = [](const OperationContext& oc) { return std::tie(oc.operation, oc.sourceLocation); };
+    return tie(*this) < tie(rhs);
   }
   OperationContext& operator=(OperationContext&& rhs) {
     operation = std::move(rhs.operation);


### PR DESCRIPTION
Summary: Comparing multi-field objects is cumbersome and error prone. Use std::tie to do the work, as it's apparently just as efficient as manually written code, but much, much more readable and safe.

Differential Revision: D45743454

