### PR TITLE
Add optional image stride for planes other than the first plane

### DIFF
--- a/vrs/DataLayoutConventions.cpp
+++ b/vrs/DataLayoutConventions.cpp
@@ -58,8 +58,9 @@ ContentBlock ImageSpec::getImageContentBlock(const ImageContentBlockSpec& base, 
   }
   if (readWidth != 0 && readHeight != 0 && readPixelFormat != PixelFormat::UNDEFINED) {
     uint32_t readStride = stride.get(); // get value or 0
+    uint32_t readStride2 = stride2.get(); // get value or 0
     if (base.getImageFormat() == ImageFormat::RAW) {
-      return ContentBlock(readPixelFormat, readWidth, readHeight, readStride);
+      return ContentBlock(readPixelFormat, readWidth, readHeight, readStride, readStride2);
     } else if (base.getImageFormat() == ImageFormat::VIDEO) {
       if (blockSize != ContentBlock::kSizeUnknown) {
         string aCodecName;
@@ -73,7 +74,13 @@ ContentBlock ImageSpec::getImageContentBlock(const ImageContentBlockSpec& base, 
         }
         return {
             ImageContentBlockSpec(
-                aCodecName, aCodecQuality, readPixelFormat, readWidth, readHeight, readStride),
+                aCodecName,
+                aCodecQuality,
+                readPixelFormat,
+                readWidth,
+                readHeight,
+                readStride,
+                readStride2),
             blockSize};
       }
     }

--- a/vrs/DataLayoutConventions.h
+++ b/vrs/DataLayoutConventions.h
@@ -42,8 +42,10 @@ class NextContentBlockSizeSpec : public AutoDataLayout {
 constexpr const char* kImageWidth = "image_width";
 /// DataLayout convention name for the image height.
 constexpr const char* kImageHeight = "image_height";
-/// DataLayout convention name for the image stride.
+/// DataLayout convention name for the image stride for the first plane.
 constexpr const char* kImageStride = "image_stride";
+/// DataLayout convention name for the image stride for the other planes (not the first plane).
+constexpr const char* kImageStride2 = "image_stride_2";
 /// DataLayout convention name for the pixel format specification (see vrs::ImageFormat).
 constexpr const char* kImagePixelFormat = "image_pixel_format";
 /// DataLayout convention name for the number of bytes per pixel, deprecated.
@@ -75,6 +77,7 @@ class ImageSpec : public AutoDataLayout {
   DataPieceValue<ImageSpecType> width{kImageWidth};
   DataPieceValue<ImageSpecType> height{kImageHeight};
   DataPieceValue<ImageSpecType> stride{kImageStride};
+  DataPieceValue<ImageSpecType> stride2{kImageStride2};
   DataPieceEnum<PixelFormat, ImageSpecType> pixelFormat{kImagePixelFormat};
 
   // For video encoding

--- a/vrs/RecordFormat.h
+++ b/vrs/RecordFormat.h
@@ -156,6 +156,7 @@ class ImageContentBlockSpec {
       uint32_t width = 0,
       uint32_t height = 0,
       uint32_t stride = 0,
+      uint32_t stride2 = 0,
       const string& codecName = {},
       uint8_t codecQuality = kQualityUndefined,
       double keyFrameTimestamp = kInvalidTimestamp,
@@ -169,7 +170,9 @@ class ImageContentBlockSpec {
       PixelFormat pixelFormat,
       uint32_t width,
       uint32_t height,
-      uint32_t stride = 0); // number of bytes between lines, if not width * sizeof(pixelFormat)
+      uint32_t stride = 0, ///< number of bytes between lines, if not width * sizeof(pixelFormat)
+      uint32_t stride2 = 0 ///< stride for planes after the first plane
+  );
 
   /// Video image with codec.
   ImageContentBlockSpec(
@@ -178,7 +181,8 @@ class ImageContentBlockSpec {
       PixelFormat pixelFormat,
       uint32_t width,
       uint32_t height,
-      uint32_t stride = 0);
+      uint32_t stride = 0,
+      uint32_t stride2 = 0);
 
   /// Constructor used for factory construction. @internal
   explicit ImageContentBlockSpec(const string& formatStr);
@@ -202,7 +206,7 @@ class ImageContentBlockSpec {
   /// Default copy assignment
   ImageContentBlockSpec& operator=(const ImageContentBlockSpec&) = default;
 
-  /// Compare two image block spec.
+  /// Compare two image block spec strictly, field by field.
   bool operator==(const ImageContentBlockSpec& rhs) const;
   bool operator!=(const ImageContentBlockSpec& rhs) const;
 
@@ -234,6 +238,9 @@ class ImageContentBlockSpec {
   /// Return 0 if no stride value was explicitly provided.
   uint32_t getRawStride() const {
     return stride_;
+  }
+  uint32_t getRawStride2() const {
+    return stride2_;
   }
 
   /// Get the number of planes for this pixel format.
@@ -310,7 +317,8 @@ class ImageContentBlockSpec {
   PixelFormat pixelFormat_{PixelFormat::UNDEFINED};
   uint32_t width_{0};
   uint32_t height_{0};
-  uint32_t stride_{0};
+  uint32_t stride_{0}; // Stride (bytes between lines) for the first pixel plane
+  uint32_t stride2_{0}; // Stride for the other planes (same for all)
   // for ImageFormat::VIDEO
   string codecName_;
   double keyFrameTimestamp_{kInvalidTimestamp};
@@ -474,10 +482,16 @@ class ContentBlock {
       PixelFormat pixelFormat = PixelFormat::UNDEFINED,
       uint32_t width = 0,
       uint32_t height = 0,
-      uint32_t stride = 0);
+      uint32_t stride = 0,
+      uint32_t stride2 = 0);
 
   /// Raw image formats: a PixelFormat and maybe resolutions & raw stride.
-  ContentBlock(PixelFormat pixelFormat, uint32_t width, uint32_t height, uint32_t stride = 0);
+  ContentBlock(
+      PixelFormat pixelFormat,
+      uint32_t width,
+      uint32_t height,
+      uint32_t stride = 0,
+      uint32_t stride2 = 0);
 
   ContentBlock(const ImageContentBlockSpec& imageSpec, size_t size = kSizeUnknown);
   ContentBlock(

--- a/vrs/test/ContentBlockReaderTest.cpp
+++ b/vrs/test/ContentBlockReaderTest.cpp
@@ -103,19 +103,19 @@ TEST_F(ContentBlockReaderTest, videoImageSpecTest) {
       {ImageFormat::VIDEO, PixelFormat::GREY8, 100, 100}, spec, ImageFormat::VIDEO, 123));
   spec.codecName.stage("H.264");
   EXPECT_TRUE(isImageSpec(
-      {ImageFormat::VIDEO, PixelFormat::GREY8, 100, 100, 0, "H.264"},
+      {ImageFormat::VIDEO, PixelFormat::GREY8, 100, 100, 0, 0, "H.264"},
       spec,
       ImageFormat::VIDEO,
       123));
   spec.codecQuality.set(23);
   EXPECT_TRUE(isImageSpec(
-      {ImageFormat::VIDEO, PixelFormat::GREY8, 100, 100, 0, "H.264", 23},
+      {ImageFormat::VIDEO, PixelFormat::GREY8, 100, 100, 0, 0, "H.264", 23},
       spec,
       ImageFormat::VIDEO,
       123));
   spec.codecQuality.set(0);
   EXPECT_TRUE(isImageSpec(
-      {ImageFormat::VIDEO, PixelFormat::GREY8, 100, 100, 0, "H.264", 0},
+      {ImageFormat::VIDEO, PixelFormat::GREY8, 100, 100, 0, 0, "H.264", 0},
       spec,
       ImageFormat::VIDEO,
       123));
@@ -126,6 +126,7 @@ TEST_F(ContentBlockReaderTest, videoImageSpecTest) {
        100,
        100,
        0,
+       0,
        "H.264",
        ImageContentBlockSpec::kQualityUndefined},
       spec,
@@ -134,7 +135,10 @@ TEST_F(ContentBlockReaderTest, videoImageSpecTest) {
   spec.codecName.stage({});
   spec.codecQuality.set(5);
   EXPECT_TRUE(isImageSpec(
-      {ImageFormat::VIDEO, PixelFormat::GREY8, 100, 100, 0, {}, 5}, spec, ImageFormat::VIDEO, 123));
+      {ImageFormat::VIDEO, PixelFormat::GREY8, 100, 100, 0, 0, {}, 5},
+      spec,
+      ImageFormat::VIDEO,
+      123));
 }
 
 TEST_F(ContentBlockReaderTest, legacySpecTest) {


### PR DESCRIPTION
Summary:
We need to support customized stride from some of the YUV multi-plane pixel formats.
From research, it appears that multiplane situations always involve a first plane with some dimension, while the other planes have identical dimensions, same or different compared to the first plane. Therefore, even for pixel formats with 3 or 4 planes, we only need one custom stride option for all the other planes.

Differential Revision: D45720400

