### PR TITLE
Rapidjson helpers clean-up

### DIFF
--- a/vrs/DataLayout.cpp
+++ b/vrs/DataLayout.cpp
@@ -1022,11 +1022,11 @@ DataPieceValue<T>::DataPieceValue(const DataPiece::MakerBundle& bundle)
   const JValue::ConstMemberIterator defaultV = bundle.piece.FindMember("default");
   if (defaultV != bundle.piece.MemberEnd()) {
     T defaultValue;
-    if (getFromRapidjsonValue(defaultV->value, defaultValue)) {
+    if (getFromJValue(defaultV->value, defaultValue)) {
       setDefault(defaultValue);
     }
   }
-  getMap(properties_, bundle.piece, "properties");
+  getJMap(properties_, bundle.piece, "properties");
 }
 
 template <typename T>
@@ -1122,8 +1122,8 @@ void DataPieceValue<T>::serialize(JsonWrapper& rj, const JsonFormatProfileSpec& 
 template <typename T>
 DataPieceArray<T>::DataPieceArray(const DataPiece::MakerBundle& bundle)
     : DataPieceArray(bundle.label, bundle.arraySize) {
-  getVector(defaultValues_, bundle.piece, "default");
-  getMap(properties_, bundle.piece, "properties");
+  getJVector(defaultValues_, bundle.piece, "default");
+  getJMap(properties_, bundle.piece, "properties");
 }
 
 namespace {
@@ -1231,7 +1231,7 @@ void DataPieceArray<T>::serialize(JsonWrapper& rj, const JsonFormatProfileSpec& 
 template <typename T>
 DataPieceVector<T>::DataPieceVector(const DataPiece::MakerBundle& bundle)
     : DataPieceVector(bundle.label) {
-  vrs::getVector(defaultValues_, bundle.piece, "default");
+  vrs::getJVector(defaultValues_, bundle.piece, "default");
 }
 
 template <>
@@ -1429,7 +1429,7 @@ void DataPieceVector<T>::serialize(JsonWrapper& rj, const JsonFormatProfileSpec&
 template <typename T>
 DataPieceStringMap<T>::DataPieceStringMap(const DataPiece::MakerBundle& bundle)
     : DataPieceStringMap(bundle.label) {
-  vrs::getMap(defaultValues_, bundle.piece, "default");
+  vrs::getJMap(defaultValues_, bundle.piece, "default");
 }
 
 template <typename T>
@@ -1542,12 +1542,12 @@ void DataPieceStringMap<T>::serialize(JsonWrapper& rj, const JsonFormatProfileSp
   if (profile.value) {
     map<string, T> values;
     if (get(values)) {
-      serializeStringMap(values, rj, "value");
+      serializeMap(values, rj, "value");
     }
   }
   DataPiece::serialize(rj, profile);
   if (profile.defaults) {
-    serializeStringMap(defaultValues_, rj, "default");
+    serializeMap(defaultValues_, rj, "default");
   }
 }
 
@@ -1670,7 +1670,7 @@ ManualDataLayout::~ManualDataLayout() {
 ManualDataLayout::ManualDataLayout(const string& json) : ManualDataLayout() {
   using namespace fb_rapidjson;
   JDocument document;
-  document.Parse(json.c_str());
+  jParse(document, json);
   // We need to assume that everything might be missing, and never crash
   if (XR_VERIFY(document.IsObject(), "Not a valid datalayout: '{}'", json)) {
     JValue::ConstMemberIterator node = document.FindMember("data_layout");

--- a/vrs/DescriptionRecord.cpp
+++ b/vrs/DescriptionRecord.cpp
@@ -111,7 +111,7 @@ static void jsonToTags(const string& jsonTags, map<string, string>& outTags) {
   using namespace fb_rapidjson;
   outTags.clear();
   Document document;
-  document.Parse(jsonTags.c_str());
+  document.Parse(jsonTags.c_str(), jsonTags.size());
   if (XR_VERIFY(document.IsObject(), "Improper tags: '{}'", jsonTags)) {
     for (Value::ConstMemberIterator itr = document.MemberBegin(); itr != document.MemberEnd();
          ++itr) {
@@ -126,7 +126,7 @@ static bool
 jsonToNameAndTags(const string& jsonStr, string& outName, map<string, string>& outTags) {
   using namespace fb_rapidjson;
   Document document;
-  document.Parse(jsonStr.c_str());
+  document.Parse(jsonStr.c_str(), jsonStr.size());
   if (!XR_VERIFY(document.IsObject(), "Improper name & tags")) {
     return false;
   }

--- a/vrs/FileSpec.cpp
+++ b/vrs/FileSpec.cpp
@@ -179,11 +179,11 @@ string FileSpec::toPathJsonUri() const {
 bool FileSpec::fromJson(const string& jsonStr) {
   using namespace fb_rapidjson;
   JDocument document;
-  document.Parse(jsonStr.c_str());
+  jParse(document, jsonStr);
   if (document.IsObject()) {
-    getString(fileName, document, kFileNameField);
-    getString(fileHandlerName, document, kFileHandlerField);
-    getString(uri, document, kUriField);
+    getJString(fileName, document, kFileNameField);
+    getJString(fileHandlerName, document, kFileHandlerField);
+    getJString(uri, document, kUriField);
     extras.clear();
     for (auto iter = document.MemberBegin(); iter != document.MemberEnd(); ++iter) {
       const auto* key = iter->name.GetString();
@@ -193,8 +193,8 @@ bool FileSpec::fromJson(const string& jsonStr) {
         extras.emplace(key, iter->value.GetString());
       }
     }
-    getVector(chunks, document, fb_rapidjson::StringRef(kChunkField));
-    getVector(chunkSizes, document, fb_rapidjson::StringRef(kChunkSizesField));
+    getJVector(chunks, document, kChunkField);
+    getJVector(chunkSizes, document, kChunkSizesField);
     return true;
   }
   clear();
@@ -206,22 +206,22 @@ string FileSpec::toJson() const {
   JDocument document;
   JsonWrapper wrapper{document};
   if (!chunks.empty()) {
-    serializeVector<string>(chunks, wrapper, StringRef(kChunkField));
+    serializeVector<string>(chunks, wrapper, kChunkField);
   }
   if (!chunkSizes.empty()) {
-    serializeVector<int64_t>(chunkSizes, wrapper, StringRef(kChunkSizesField));
+    serializeVector<int64_t>(chunkSizes, wrapper, kChunkSizesField);
   }
   if (!fileHandlerName.empty()) {
-    wrapper.addMember(kFileHandlerField, fileHandlerName);
+    wrapper.addMember(kFileHandlerField, jStringRef(fileHandlerName));
   }
   if (!fileName.empty()) {
-    wrapper.addMember(kFileNameField, fileName);
+    wrapper.addMember(kFileNameField, jStringRef(fileName));
   }
   if (!uri.empty()) {
-    wrapper.addMember(kUriField, uri);
+    wrapper.addMember(kUriField, jStringRef(uri));
   }
   for (const auto& extra : extras) {
-    wrapper.addMember(extra.first, extra.second);
+    wrapper.addMember(extra.first, jStringRef(extra.second));
   }
   return jDocumentToJsonString(document);
 }

--- a/vrs/TagConventions.cpp
+++ b/vrs/TagConventions.cpp
@@ -43,7 +43,7 @@ string tag_conventions::makeTagSet(const vector<string>& tags) {
   using namespace fb_rapidjson;
   JDocument doc;
   JsonWrapper wrapper{doc};
-  serializeVector<string>(tags, wrapper, fb_rapidjson::StringRef(cTagsObjectName));
+  serializeVector<string>(tags, wrapper, cTagsObjectName);
   return jDocumentToJsonString(doc);
 }
 
@@ -51,9 +51,9 @@ bool tag_conventions::parseTagSet(const string& jsonTagSet, vector<string>& outV
   outVectorTagSet.clear();
   using namespace fb_rapidjson;
   JDocument document;
-  document.Parse(jsonTagSet.c_str());
+  jParse(document, jsonTagSet);
   if (document.IsObject()) {
-    getVector(outVectorTagSet, document, fb_rapidjson::StringRef(cTagsObjectName));
+    getJVector(outVectorTagSet, document, cTagsObjectName);
     return true;
   }
   return false;

--- a/vrs/helpers/Rapidjson.hpp
+++ b/vrs/helpers/Rapidjson.hpp
@@ -341,6 +341,17 @@ inline bool getInt(int& outInt, const JValue& piece, const char* name) {
   return false;
 }
 
+inline bool getJDouble(double& outDouble, const JValue& piece, const char* name) {
+  using namespace fb_rapidjson;
+  const JValue::ConstMemberIterator member = piece.FindMember(name);
+  if (member != piece.MemberEnd() && member->value.IsDouble()) {
+    outDouble = member->value.GetDouble();
+    return true;
+  }
+  outDouble = 0;
+  return false;
+}
+
 // double -> json -> double & float -> json -> float don't preserve prefect accuracy
 // These methods are used to verify "reasonable" accuracy of serialization/deserialization... :-(
 template <typename T>


### PR DESCRIPTION
Summary:
- renamed a json helper functions to be more specific, to reduce chances of name collisions
- parameter types clean-up for consistency, better match underlying API, or address linter comment
- removed duplicate local helper function (same name, different parameter order)
- use helper in a few places where we could have.

No behavior change expected.

Differential Revision: D46267101

