### PR TITLE
Further json serialization optimizations

### DIFF
--- a/vrs/DataLayout.cpp
+++ b/vrs/DataLayout.cpp
@@ -984,7 +984,7 @@ string DataPiece::getTypeName() const {
 void DataPiece::serialize(JsonWrapper& rj, const JsonFormatProfileSpec& profile) {
   using namespace fb_rapidjson;
   if (profile.name) {
-    rj.addMember("name", getLabel());
+    rj.addMember("name", jStringRef(getLabel()));
   }
   if (profile.type) {
     string typeName = getTypeName();
@@ -1004,7 +1004,7 @@ void DataPiece::serialize(JsonWrapper& rj, const JsonFormatProfileSpec& profile)
     }
   }
   if (profile.tags) {
-    serializeMap(tags_, rj, "tags");
+    serializeStringRefMap(tags_, rj, "tags");
   }
   if (profile.required && isRequired()) {
     rj.addMember("required", true);

--- a/vrs/FileSpec.cpp
+++ b/vrs/FileSpec.cpp
@@ -206,7 +206,7 @@ string FileSpec::toJson() const {
   JDocument document;
   JsonWrapper wrapper{document};
   if (!chunks.empty()) {
-    serializeVector<string>(chunks, wrapper, kChunkField);
+    serializeStringRefVector(chunks, wrapper, kChunkField);
   }
   if (!chunkSizes.empty()) {
     serializeVector<int64_t>(chunkSizes, wrapper, kChunkSizesField);

--- a/vrs/TagConventions.cpp
+++ b/vrs/TagConventions.cpp
@@ -43,7 +43,7 @@ string tag_conventions::makeTagSet(const vector<string>& tags) {
   using namespace fb_rapidjson;
   JDocument doc;
   JsonWrapper wrapper{doc};
-  serializeVector<string>(tags, wrapper, cTagsObjectName);
+  serializeStringRefVector(tags, wrapper, cTagsObjectName);
   return jDocumentToJsonString(doc);
 }
 

--- a/vrs/helpers/Rapidjson.hpp
+++ b/vrs/helpers/Rapidjson.hpp
@@ -143,6 +143,20 @@ inline void serializeMap(const map<string, T>& amap, JsonWrapper& rj, const JSTR
   }
 }
 
+// when the map<string, string> will live as long as the json serialization (avoid string copies)
+template <typename JSTR>
+inline void
+serializeStringRefMap(const map<string, string>& stringMap, JsonWrapper& rj, const JSTR& name) {
+  using namespace fb_rapidjson;
+  if (stringMap.size() > 0) {
+    JValue mapValues(kObjectType);
+    for (const auto& element : stringMap) {
+      mapValues.AddMember(jStringRef(element.first), jStringRef(element.second), rj.alloc);
+    }
+    rj.addMember(name, mapValues);
+  }
+}
+
 template <typename T, typename JSTR>
 inline void serializeVector(const vector<T>& vect, JsonWrapper& rj, const JSTR& name) {
   using namespace fb_rapidjson;
@@ -151,6 +165,21 @@ inline void serializeVector(const vector<T>& vect, JsonWrapper& rj, const JSTR& 
     arrayValues.Reserve(static_cast<SizeType>(vect.size()), rj.alloc);
     for (const auto& element : vect) {
       arrayValues.PushBack(rj.jValue(element), rj.alloc);
+    }
+    rj.addMember(name, arrayValues);
+  }
+}
+
+// when the vector<string> will live as long as the json serialization (avoid string copies)
+template <typename JSTR>
+inline void
+serializeStringRefVector(const vector<string>& vect, JsonWrapper& rj, const JSTR& name) {
+  using namespace fb_rapidjson;
+  if (vect.size() > 0) {
+    JValue arrayValues(kArrayType);
+    arrayValues.Reserve(static_cast<SizeType>(vect.size()), rj.alloc);
+    for (const auto& str : vect) {
+      arrayValues.PushBack(jStringRef(str), rj.alloc);
     }
     rj.addMember(name, arrayValues);
   }


### PR DESCRIPTION
Summary:
When serializing strings, in particular containers of strings, we can avoid copying one string copy by using StringRef rather than JValue, but only if the string will live until the serialization is over.
No expected visible change.

Differential Revision: D46281100

