### PR TITLE
Allow vrs-cli commands to be passed as Desktop App arguments

### DIFF
--- a/tools/vrs/VrsCommand.cpp
+++ b/tools/vrs/VrsCommand.cpp
@@ -52,6 +52,8 @@ using vrs::RecordFileInfo::Details;
 
 namespace {
 
+using namespace vrscli;
+
 const char* sCommands[] = {
     "none",
     "help",
@@ -138,6 +140,8 @@ const CommandSpec& getCommandSpec(Command cmd) {
 } // namespace
 
 #define CMD(H, C) H ":\n  " << appName << " " C "\n"
+
+namespace vrscli {
 
 void printHelp(const string& appName) {
   cout
@@ -632,3 +636,5 @@ DecimationParams& VrsCommand::getDecimatorParams() {
   }
   return *filters.decimationParams;
 }
+
+} // namespace vrscli

--- a/tools/vrs/VrsCommand.h
+++ b/tools/vrs/VrsCommand.h
@@ -23,6 +23,7 @@
 #include <vrs/utils/Validation.h>
 #include <vrs/utils/cli/PrintRecordFormatRecords.h>
 
+namespace vrscli {
 void printHelp(const std::string& appName);
 void printSamples(const std::string& appName);
 
@@ -139,3 +140,5 @@ struct VrsCommand {
   /// Extract raw images as ".raw" files instead of converting them to png.
   bool extractImagesRaw = false;
 };
+
+} // namespace vrscli

--- a/tools/vrs/test/VrsAppTest.cpp
+++ b/tools/vrs/test/VrsAppTest.cpp
@@ -33,6 +33,7 @@
 using namespace std;
 using namespace vrs;
 using namespace vrs::utils;
+using namespace vrscli;
 
 using coretech::getTestDataDir;
 

--- a/tools/vrs/test/VrsCommandTest.cpp
+++ b/tools/vrs/test/VrsCommandTest.cpp
@@ -26,6 +26,7 @@
 
 using namespace std;
 using namespace vrs::utils;
+using namespace vrscli;
 
 using coretech::getTestDataDir;
 

--- a/tools/vrs/vrs.cpp
+++ b/tools/vrs/vrs.cpp
@@ -21,6 +21,7 @@
 #include <vrs/os/Utils.h>
 
 using namespace std;
+using namespace vrscli;
 
 int main(int argc, char** argv) {
   const string& appName = vrs::os::getFilename(argv[0]);


### PR DESCRIPTION
Summary: Encapsulate the vrs cli files with dedicated namespace.

Reviewed By: georges-berenger

Differential Revision: D46758983

