### PR TITLE
Add WorldObserverCameraRecordableClass with id 216 to StreamId and Recorder

### DIFF
--- a/vrs/StreamId.cpp
+++ b/vrs/StreamId.cpp
@@ -57,6 +57,7 @@ const map<RecordableTypeId, const char*>& getRecordableTypeIdRegistry() {
     {RecordableTypeId::RgbCameraRecordableClass, "RGB Camera Class"},
     {RecordableTypeId::SlamCameraData, "Camera Data (SLAM)"},
     {RecordableTypeId::DisplayObserverCameraRecordableClass, "Display Observing Camera Class"},
+    {RecordableTypeId::WorldObserverCameraRecordableClass, "World Observing Camera Class"},
 
     /// << Microphones >>
     {RecordableTypeId::MonoAudioRecordableClass, "Mono Audio Class"},

--- a/vrs/StreamId.h
+++ b/vrs/StreamId.h
@@ -83,6 +83,7 @@ enum class RecordableTypeId : uint16_t {
   MouthCameraRecordableClass = 213, ///< For cameras recording a mouth.
   RgbCameraRecordableClass = 214, ///< For color cameras.
   DisplayObserverCameraRecordableClass = 215, ///< For display observing cameras.
+  WorldObserverCameraRecordableClass = 216, ///< For world observing cameras.
 
   // << Microphones >>
   MonoAudioRecordableClass = 230, ///< For mono microphones.


### PR DESCRIPTION
Summary: This adds a separate camera stream for the WorldObservingCameras (WOCs) with a distinct stream id 216. WOCs are cameras that are rigidly attached to the DOCs (display observing cameras) but not influenced by the DUT's optical stack.

Differential Revision: D48199258

