### PR TITLE
Fix OSS build

### DIFF
--- a/vrs/os/Utils.h
+++ b/vrs/os/Utils.h
@@ -18,7 +18,9 @@
 
 #include <cstdint>
 #include <cstdio>
+
 #include <string>
+#include <vector>
 
 #include <vrs/os/Platform.h>
 


### PR DESCRIPTION
Summary: Recent clang-tidy clean-ups broke the build in OSS.

Differential Revision:
D52844236

Privacy Context Container: L1181955


