### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,8 @@ jobs:
           current_tag=$(echo $output | awk '{print $2}')
           echo "current version is $current_version"
           echo "current tag is $current_tag"
-          echo ::set-output name=version::$current_version
-          echo ::set-output name=tag::$current_tag
+          echo "version=$current_version" >> $GITHUB_OUTPUT
+          echo "tag=$current_tag" >> $GITHUB_OUTPUT
     outputs:
       current_version: ${{ steps.get-current-version-and-tag.outputs.version }}
       current_tag: ${{ steps.get-current-version-and-tag.outputs.tag }}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter