### PR TITLE
Fix logging for open source project

### DIFF
--- a/vrs/AsyncDiskFileChunk.hpp
+++ b/vrs/AsyncDiskFileChunk.hpp
@@ -27,6 +27,7 @@
 #include <unistd.h>
 #endif
 
+#include <atomic>
 #include <condition_variable>
 #include <deque>
 #include <functional>
@@ -468,7 +469,7 @@ class AlignedBuffer {
     if (size_ >= capacity) {
       throw std::runtime_error("buffer is already at capacity");
     }
-    auto tocopy = std::min(size, capacity - size_);
+    size_t tocopy = std::min<size_t>(size, capacity - size_);
     memcpy(bdata() + size_, buffer, tocopy);
     size_ += tocopy;
 
@@ -784,7 +785,7 @@ class AsyncDiskFileChunk {
         use_directio_ && (current_buffer_ == nullptr || current_buffer_->empty()) &&
         (file_position_ % offset_align_) != 0) {
       // Write as much as we need to in order to hit offset_align_, then fill the buffers
-      towrite = std::min(count, offset_align_ - (file_position_ % offset_align_));
+      towrite = std::min<size_t>(count, offset_align_ - (file_position_ % offset_align_));
     } // Otherwise writes can be aligned to anything, write nothing synchronously here
 
     if (towrite != 0) {
@@ -1268,9 +1269,9 @@ class AsyncDiskFileChunk {
       // the assumption that the underlying write() calls will fail if they're bad values.
 
       uint64_t temp_u64 = 0;
-      mem_align_ =
-          std::max(mem_align_, helpers::getUInt64(options, "mem_align", temp_u64) ? temp_u64 : 04);
-      offset_align_ = std::max(
+      mem_align_ = std::max<size_t>(
+          mem_align_, helpers::getUInt64(options, "mem_align", temp_u64) ? temp_u64 : 04);
+      offset_align_ = std::max<size_t>(
           offset_align_, helpers::getUInt64(options, "offset_align", temp_u64) ? temp_u64 : 04);
 
       // The defaults below might not be optimal for your rig.

--- a/vrs/oss/logging/Log.h
+++ b/vrs/oss/logging/Log.h
@@ -20,10 +20,6 @@
 
 #include <fmt/core.h>
 
-#ifndef DEFAULT_LOG_CHANNEL
-#error "DEFAULT_LOG_CHANNEL must be defined before including <logging/Log.h>"
-#endif // DEFAULT_LOG_CHANNEL
-
 namespace vrs {
 namespace logging {
 
@@ -52,6 +48,7 @@ void log_every_n_seconds(
 } // namespace logging
 } // namespace vrs
 
+#ifdef DEFAULT_LOG_CHANNEL
 #define XR_LOG_DEFAULT(level, ...) log(level, DEFAULT_LOG_CHANNEL, fmt::format(__VA_ARGS__))
 #define XR_LOG_EVERY_N_SEC_DEFAULT(level, nseconds, ...) \
   log_every_n_seconds(                                   \
@@ -70,3 +67,11 @@ void log_every_n_seconds(
   XR_LOG_EVERY_N_SEC_DEFAULT(vrs::logging::Level::Warning, nseconds, __VA_ARGS__)
 #define XR_LOGE_EVERY_N_SEC(nseconds, ...) \
   XR_LOG_EVERY_N_SEC_DEFAULT(vrs::logging::Level::Error, nseconds, __VA_ARGS__)
+#endif
+
+#define XR_LOG_CHANNEL(level, channel, ...) log(level, channel, fmt::format(__VA_ARGS__))
+
+#define XR_LOGCD(CHANNEL, ...) XR_LOG_CHANNEL(vrs::logging::Level::Debug, CHANNEL, __VA_ARGS__)
+#define XR_LOGCI(CHANNEL, ...) XR_LOG_CHANNEL(vrs::logging::Level::Info, CHANNEL, __VA_ARGS__)
+#define XR_LOGCW(CHANNEL, ...) XR_LOG_CHANNEL(vrs::logging::Level::Warning, CHANNEL, __VA_ARGS__)
+#define XR_LOGCE(CHANNEL, ...) XR_LOG_CHANNEL(vrs::logging::Level::Error, CHANNEL, __VA_ARGS__)


### PR DESCRIPTION
Summary: The OSS logging macros only include definitions using the default log channel. This diff adds explicit log channel logging macros.

Differential Revision: D60429457
