### PR TITLE
Don't use ZSTD_defaultCLevel() as it's not available on older versions of zstd

### DIFF
--- a/vrs/Compressor.cpp
+++ b/vrs/Compressor.cpp
@@ -96,7 +96,7 @@ struct CompressionPresetConverter : public EnumStringConverter<
 int zstdPresetToCompressionLevel(CompressionPreset preset) {
   auto iter = sZstdPresets.find(preset);
   if (iter == sZstdPresets.end()) {
-    return ZSTD_defaultCLevel();
+    return ZSTD_CLEVEL_DEFAULT;
   }
   return iter->second;
 }


### PR DESCRIPTION
Summary: ZSTD_defaultCLevel() isn't always available on the version of zstd we get in open source, breaking some CI builds on GitHub, but ZSTD_CLEVEL_DEFAULT goes back to version v1.3.5.

Differential Revision: D60815132
