### PR TITLE
{Build} Remove unused boost dependencies

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,7 +27,7 @@ jobs:
               cmake git ninja-build libgtest-dev libfmt-dev \
               libturbojpeg-dev libpng-dev \
               liblz4-dev libzstd-dev libxxhash-dev \
-              libboost-system-dev libboost-filesystem-dev libboost-thread-dev libboost-chrono-dev libboost-date-time-dev \
+              libboost-system-dev libboost-filesystem-dev libboost-date-time-dev \
               qtbase5-dev portaudio19-dev
 
           elif [ "$RUNNER_OS" == "macOS" ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM ubuntu:jammy
 RUN apt-get update && DEBIAN_FRONTEND="noninteractive" TZ="America/New_York" apt-get install -y tzdata
 RUN apt-get install -y git cmake ninja-build ccache libgtest-dev libfmt-dev libturbojpeg-dev\
     libpng-dev liblz4-dev libzstd-dev libxxhash-dev\
-    libboost-system-dev libboost-filesystem-dev libboost-thread-dev libboost-chrono-dev libboost-date-time-dev\
+    libboost-system-dev libboost-filesystem-dev libboost-date-time-dev\
     qtbase5-dev portaudio19-dev\
     npm doxygen;
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ therefore not supported._
   ```
   sudo apt-get install cmake git ninja-build ccache libgtest-dev libfmt-dev libturbojpeg-dev libpng-dev
   sudo apt-get install liblz4-dev libzstd-dev libxxhash-dev
-  sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-thread-dev libboost-chrono-dev libboost-date-time-dev
+  sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-date-time-dev
   sudo apt-get install qtbase5-dev portaudio19-dev
   sudo apt-get install npm doxygen
   ```

--- a/cmake/LibrariesSetup.cmake
+++ b/cmake/LibrariesSetup.cmake
@@ -20,11 +20,10 @@ endif()
 find_package(Boost REQUIRED
   COMPONENTS
     filesystem
-    chrono
     date_time
     system
-    thread
 )
+find_package(Threads REQUIRED)
 find_package(FmtLib REQUIRED)
 find_package(RapidjsonLib REQUIRED)
 find_package(Lz4 REQUIRED)

--- a/vrs/os/CMakeLists.txt
+++ b/vrs/os/CMakeLists.txt
@@ -32,9 +32,8 @@ target_link_libraries(vrs_os
     vrs_logging
     Boost::system
     Boost::filesystem
-    Boost::thread
-    Boost::chrono
     Boost::date_time
+    Threads::Threads
 )
 target_compile_definitions(vrs_os INTERFACE OSS_BUILD_MODE)
 


### PR DESCRIPTION
Summary: Boost chrono and thread are not longer required, we are removing here reference to them.

Differential Revision: D61272926
