### PR TITLE
allow `asyncdiskfile:` on windows+clang

### DIFF
--- a/vrs/DiskFile.h
+++ b/vrs/DiskFile.h
@@ -172,7 +172,7 @@ class DiskFileT : public WriteFileHandler {
 
 using DiskFile = DiskFileT<DiskFileChunk>;
 
-#if (IS_LINUX_PLATFORM() && IS_X86_PLATFORM()) || (IS_WINDOWS_PLATFORM() && !defined(__clang__))
+#if (IS_LINUX_PLATFORM() && IS_X86_PLATFORM()) || (IS_WINDOWS_PLATFORM())
 #define VRS_ASYNC_DISKFILE_SUPPORTED() true
 
 class AsyncDiskFileChunk;


### PR DESCRIPTION
Summary: Clang seems to compile this okay, enable this functionality

Reviewed By: georges-berenger

Differential Revision: D61921432
