### PR TITLE
Disable asyncdiskfile tests on windows/oss

### DIFF
--- a/vrs/test/file_tests/DeviceSimulatorTest.cpp
+++ b/vrs/test/file_tests/DeviceSimulatorTest.cpp
@@ -25,6 +25,7 @@
 
 #include <vrs/DiskFile.h>
 #include <vrs/RecordFileReader.h>
+#include <vrs/os/Platform.h>
 #include <vrs/os/Utils.h>
 
 #include <vrs/test/helpers/VRSTestsHelpers.h>
@@ -127,6 +128,7 @@ TEST_F(DeviceSimulator, multiThreadAsyncAioNotDirect) {
   deleteChunkedFile(testPath);
 }
 
+#if IS_VRS_FB_INTERNAL() || !IS_WINDOWS_PLATFORM() // avoid OSS/Windows
 TEST_F(DeviceSimulator, multiThreadAsyncSync) {
   const string testPath = os::getTempFolder() + "MultiThreadAsyncSync.vrs";
 
@@ -138,6 +140,7 @@ TEST_F(DeviceSimulator, multiThreadAsyncSync) {
 
   deleteChunkedFile(testPath);
 }
+#endif
 
 TEST_F(DeviceSimulator, multiThreadAsyncPsync) {
   const string testPath = os::getTempFolder() + "MultiThreadAsyncPsync.vrs";


### PR DESCRIPTION
Summary: We're seeing failures in OSS/Windows tests only, let's disable for now.

Differential Revision: D61964703
