### PR TITLE
handle cases where ReadFile/WriteFile may complete synchronously

### DIFF
--- a/vrs/test/file_tests/DeviceSimulatorTest.cpp
+++ b/vrs/test/file_tests/DeviceSimulatorTest.cpp
@@ -25,7 +25,6 @@
 
 #include <vrs/DiskFile.h>
 #include <vrs/RecordFileReader.h>
-#include <vrs/os/Platform.h>
 #include <vrs/os/Utils.h>
 
 #include <vrs/test/helpers/VRSTestsHelpers.h>
@@ -128,7 +127,6 @@ TEST_F(DeviceSimulator, multiThreadAsyncAioNotDirect) {
   deleteChunkedFile(testPath);
 }
 
-#if IS_VRS_FB_INTERNAL() || !IS_WINDOWS_PLATFORM() // avoid OSS/Windows
 TEST_F(DeviceSimulator, multiThreadAsyncSync) {
   const string testPath = os::getTempFolder() + "MultiThreadAsyncSync.vrs";
 
@@ -140,7 +138,6 @@ TEST_F(DeviceSimulator, multiThreadAsyncSync) {
 
   deleteChunkedFile(testPath);
 }
-#endif
 
 TEST_F(DeviceSimulator, multiThreadAsyncPsync) {
   const string testPath = os::getTempFolder() + "MultiThreadAsyncPsync.vrs";


### PR DESCRIPTION
Summary:
Unlike `ReadFileEx` and `WriteFileEx`, which always call their completion routines and are always asynchrous, `ReadFlie` and `WriteFiel` may complete synchronously. [This MSDN article](https://learn.microsoft.com/en-us/previous-versions/troubleshoot/windows/win32/asynchronous-disk-io-synchronous) discusses how to handle this (which is different from some of the advice given in ReadFile's documentation. That says
> The lpNumberOfBytesRead parameter should be set to NULL. Use the GetOverlappedResult function to get the actual number of bytes read.

If you do that, there's no way to know how many bytes were transferred if the operation completes synchronously.

Differential Revision: D61977068
