### PR TITLE
{Build} Enhance build stability

### DIFF
--- a/tools/vrsplayer/CMakeLists.txt
+++ b/tools/vrsplayer/CMakeLists.txt
@@ -39,6 +39,7 @@ if (QT_FOUND)
       Qt${QT_VERSION_MAJOR}::Gui
       Qt${QT_VERSION_MAJOR}::Widgets
       vrs_logging
+      Threads::Threads
   )
 
   install(TARGETS vrsplayer EXPORT VRSLibTargets

--- a/tools/vrsplayer/FrameWidget.cpp
+++ b/tools/vrsplayer/FrameWidget.cpp
@@ -32,6 +32,8 @@
 #include <qscreen.h>
 #endif
 
+#include <fmt/ranges.h>
+
 #define DEFAULT_LOG_CHANNEL "FrameWidget"
 #include <logging/Log.h>
 #include <vrs/TagConventions.h>

--- a/vrs/CMakeLists.txt
+++ b/vrs/CMakeLists.txt
@@ -30,9 +30,14 @@ target_link_libraries(vrslib
     vrs_logging
     vrs_os
     vrs_utils_xxhash
+)
+target_link_libraries(vrslib
+  PRIVATE
     Lz4::Lz4
     Zstd::Zstd
 )
+
+target_link_libraries (vrslib PUBLIC $<$<PLATFORM_ID:Linux>:rt>)
 
 install(TARGETS vrslib EXPORT VRSLibTargets
   LIBRARY DESTINATION lib

--- a/vrs/utils/cli/CMakeLists.txt
+++ b/vrs/utils/cli/CMakeLists.txt
@@ -15,11 +15,21 @@
 file (GLOB VRS_UTILS_CLI_SRCS *.cpp *.h *.hpp)
 
 add_library(vrs_utils_cli ${VRS_UTILS_CLI_SRCS})
-target_include_directories(vrs_utils_cli PUBLIC ${VRS_SOURCE_DIR})
+target_include_directories(vrs_utils_cli
+  PUBLIC
+    $<BUILD_INTERFACE:${VRS_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
 target_link_libraries(vrs_utils_cli
   PUBLIC
     vrs_utils
   PRIVATE
     vrs_helpers
     vrs_logging
+)
+install(TARGETS vrs_utils_cli EXPORT VRSLibTargets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
 )


### PR DESCRIPTION
Summary:
- Better support recent fmt library update
  - `fmt::join` needs an include

- Better support of CMake install
  - vrs_utils_cli needs to be installed

- VrsPlayer is Thread dependent
  - need to be linked to Threads

- Linux `rt` library is required
  - to fix `undefined reference to aio_write` & `undefined reference to aio_return` on some distributions

- `lz4` and `zstd` does not need to leak to client (only used in cpp)
  - they can be linked privately

Differential Revision: D62672156
