### PR TITLE
include algorithm to fix build fail

### DIFF
--- a/vrs/helpers/JobQueue.h
+++ b/vrs/helpers/JobQueue.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <mutex>
 #include <thread>
+#include <algorithm>
 
 #include <vrs/os/Time.h>
 

--- a/vrs/test/DataLayoutTest.cpp
+++ b/vrs/test/DataLayoutTest.cpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <limits>
 #include <type_traits>
+#include <algorithm>
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
I encountered problem when I build with "ninja all" command
```bash
/home/leus/prog/vrs/vrs/helpers/JobQueue.h: In member function 'void vrs::JobQueue<T>::cancelQueuedJobs(std::function<bool(const T&)>, std::function<void(const T&)>)':
/home/leus/prog/vrs/vrs/helpers/JobQueue.h:118:22: error: 'remove_if' is not a member of 'std'; did you mean 'remove_cv'?
  118 |     auto iter = std::remove_if(queue_.begin(), queue_.end(), selector);


/home/leus/prog/vrs/vrs/test/DataLayoutTest.cpp:146:42: error: 'count' was not declared in this scope
  146 |   size_t lineCount = static_cast<size_t>(count(json.begin(), json.end(), '\n'));
```

This PR will fix problem above.
