### PR TITLE
pyvrs required fixes

### DIFF
--- a/tools/vrsplayer/FrameWidget.cpp
+++ b/tools/vrsplayer/FrameWidget.cpp
@@ -32,6 +32,7 @@
 #include <qscreen.h>
 #endif
 
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 
 #define DEFAULT_LOG_CHANNEL "FrameWidget"

--- a/vrs/test/MultiRecordFileReaderTest.cpp
+++ b/vrs/test/MultiRecordFileReaderTest.cpp
@@ -20,6 +20,7 @@
 #include <string>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <fmt/xchar.h>
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
Summary:
- fmt::join has been moved in the fmt library from one header to another. We need to include both location to be sure to build in all context and in open source with older and newer versions of fmt.
- make sure the vrs hash is current

Differential Revision: D66797878


