### PR TITLE
Update OSS instructions for new brew package name for jpeg

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
             sudo apt-get upgrade
             sudo apt-get install -o Acquire::Retries=5 \
               cmake git ninja-build libgtest-dev libfmt-dev \
-              libturbojpeg-dev libpng-dev \
+              libjpeg-dev libturbojpeg-dev libpng-dev \
               liblz4-dev libzstd-dev libxxhash-dev \
               libboost-system-dev libboost-filesystem-dev libboost-date-time-dev \
               qtbase5-dev portaudio19-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM ubuntu:jammy
 
 # Get dependencies
 RUN apt-get update && DEBIAN_FRONTEND="noninteractive" TZ="America/New_York" apt-get install -y tzdata
-RUN apt-get install -y git cmake ninja-build ccache libgtest-dev libfmt-dev libturbojpeg-dev\
+RUN apt-get install -y git cmake ninja-build ccache libgtest-dev libfmt-dev libjpeg-dev libturbojpeg-dev\
     libpng-dev liblz4-dev libzstd-dev libxxhash-dev\
     libboost-system-dev libboost-filesystem-dev libboost-date-time-dev\
     qtbase5-dev portaudio19-dev\

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ system.
   [Brew’s web site](https://brew.sh/).
 - install tools & libraries:
   ```
-  brew install cmake git ninja ccache boost fmt libpng jpeg-turbo libjpeg-dev lz4 zstd xxhash glog googletest
+  brew install cmake git ninja ccache boost fmt libpng jpeg jpeg-turbo lz4 zstd xxhash glog googletest
   brew install qt5 portaudio pybind11
   brew install node doxygen
   ```
@@ -92,7 +92,7 @@ therefore not supported._
 
 - install tools & libraries:
   ```
-  sudo apt-get install cmake git ninja-build ccache libgtest-dev libfmt-dev libturbojpeg-dev libpng-dev
+  sudo apt-get install cmake git ninja-build ccache libgtest-dev libfmt-dev libjpeg-dev libturbojpeg-dev libpng-dev
   sudo apt-get install liblz4-dev libzstd-dev libxxhash-dev
   sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-date-time-dev
   sudo apt-get install qtbase5-dev portaudio19-dev


### PR DESCRIPTION
Summary:
In pull request 154, there was a mixup between mac and ubuntu packages.
The package name for jpeg in Brew is "jpeg", whereas it's "libjpeg-dev" in Ubuntu.

Differential Revision:
D68055117

Privacy Context Container: L1181955


