### PR TITLE
Prefer using unique_ptr<PixelFrame> over shared_ptr<PixelFrame>

### DIFF
--- a/tools/vrsplayer/FileReader.cpp
+++ b/tools/vrsplayer/FileReader.cpp
@@ -144,6 +144,7 @@ bool FileReader::isAtEnd() const {
 
 void FileReader::closeFile() {
   stop();
+  setState(FileReaderState::NoMedia);
   if (fileConfig_) {
     saveConfiguration();
     fileConfig_.reset();

--- a/tools/vrsplayer/FramePlayer.h
+++ b/tools/vrsplayer/FramePlayer.h
@@ -51,7 +51,7 @@ using ::vrs::StreamPlayer;
 using ::vrs::utils::PixelFrame;
 using ::vrs::utils::VideoRecordFormatStreamPlayer;
 
-using ImageJob = shared_ptr<PixelFrame>;
+using ImageJob = unique_ptr<PixelFrame>;
 
 class FramePlayer : public QObject, public VideoRecordFormatStreamPlayer {
   Q_OBJECT
@@ -91,8 +91,7 @@ class FramePlayer : public QObject, public VideoRecordFormatStreamPlayer {
  private:
   std::mutex videoDecodingMutex_;
   std::mutex frameMutex_;
-  vector<shared_ptr<PixelFrame>> inputFrames_;
-  vector<shared_ptr<PixelFrame>> convertedframes_;
+  std::deque<unique_ptr<PixelFrame>> recycledFrames_;
   vrs::utils::NormalizeOptions normalizeOptions_;
   bool needsConvertedFrame_{false};
   vrs::ImageFormat imageFormat_{vrs::ImageFormat::UNDEFINED};
@@ -110,10 +109,10 @@ class FramePlayer : public QObject, public VideoRecordFormatStreamPlayer {
 
   vrs::JobQueueWithThread<std::unique_ptr<ImageJob>> imageJobs_;
 
-  void convertFrame(shared_ptr<PixelFrame>& frame);
-  static void makeBlankFrame(shared_ptr<PixelFrame>& frame);
-  shared_ptr<PixelFrame> getFrame(bool inputNotConvertedFrame);
-  void recycle(shared_ptr<PixelFrame>& frame, bool inputNotConvertedFrame);
+  void convertFrame(unique_ptr<PixelFrame>& frame);
+  static void makeBlankFrame(unique_ptr<PixelFrame>& frame);
+  unique_ptr<PixelFrame> getFrame(vrs::PixelFormat format);
+  void recycle(unique_ptr<PixelFrame>& frame);
   bool saveFrame(const CurrentRecord& record, const ContentBlock& contentBlock);
 };
 

--- a/tools/vrsplayer/FrameWidget.cpp
+++ b/tools/vrsplayer/FrameWidget.cpp
@@ -71,6 +71,8 @@ FrameWidget::FrameWidget(QWidget* parent) {
   connect(this, &FrameWidget::customContextMenuRequested, this, &FrameWidget::ShowContextMenu);
 }
 
+FrameWidget::~FrameWidget() = default;
+
 void FrameWidget::paintEvent(QPaintEvent* evt) {
   QPainter painter(this);
   painter.setRenderHint(QPainter::Antialiasing);
@@ -176,7 +178,7 @@ int FrameWidget::heightForWidth(int w) const {
   return (w * size.height()) / size.width();
 }
 
-void FrameWidget::swapImage(shared_ptr<PixelFrame>& image) {
+void FrameWidget::swapImage(unique_ptr<PixelFrame>& image) {
   unique_lock<mutex> lock;
   imageFps_.newFrame();
   bool resize = image && image->qsize() != imageSize_;
@@ -198,17 +200,15 @@ int FrameWidget::saveImage(const std::string& path) {
 }
 
 void FrameWidget::updateMinMaxSize() {
-  if (image_) {
-    QSize size = getImageSize();
-    setMinimumSize(size.scaled(100, 100, Qt::KeepAspectRatio));
-    setBaseSize(size);
+  QSize size = getImageSize();
+  setMinimumSize(size.scaled(100, 100, Qt::KeepAspectRatio));
+  setBaseSize(size);
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    QSize screenSize = QApplication::desktop()->screenGeometry(this).size().operator*=(0.95);
+  QSize screenSize = QApplication::desktop()->screenGeometry(this).size().operator*=(0.95);
 #else
-    QSize screenSize = screen()->geometry().size() * 0.95;
+  QSize screenSize = screen()->geometry().size() * 0.95;
 #endif
-    setMaximumSize(size.scaled(screenSize, Qt::KeepAspectRatio));
-  }
+  setMaximumSize(size.scaled(screenSize, Qt::KeepAspectRatio));
 }
 
 void FrameWidget::ShowContextMenu(const QPoint& pos) {

--- a/tools/vrsplayer/FrameWidget.h
+++ b/tools/vrsplayer/FrameWidget.h
@@ -37,8 +37,8 @@ class PixelFrame;
 namespace vrsp {
 
 using std::map;
-using std::shared_ptr;
 using std::string;
+using std::unique_ptr;
 using vrs::utils::PixelFrame;
 
 // Frame Per Second estimator class
@@ -78,6 +78,7 @@ class FrameWidget : public QWidget {
   Q_OBJECT
  public:
   explicit FrameWidget(QWidget* parent = nullptr);
+  ~FrameWidget() override;
 
   void paintEvent(QPaintEvent* evt) override;
   QSize sizeHint() const override;
@@ -116,7 +117,7 @@ class FrameWidget : public QWidget {
     return flipped_;
   }
 
-  void swapImage(shared_ptr<PixelFrame>& image);
+  void swapImage(unique_ptr<PixelFrame>& image);
   int saveImage(const string& path);
 
   void setTypeToShow(Record::Type type) {
@@ -154,7 +155,7 @@ class FrameWidget : public QWidget {
 
  private:
   std::mutex mutex_;
-  shared_ptr<PixelFrame> image_;
+  unique_ptr<PixelFrame> image_;
   string deviceTypeTag_;
   string deviceTypeConfig_;
   QSize imageSize_{640, 480};

--- a/vrs/utils/PixelFrame.cpp
+++ b/vrs/utils/PixelFrame.cpp
@@ -1035,7 +1035,7 @@ PixelFrame::getStreamNormalizeOptions(RecordFileReader& reader, StreamId id, Pix
 #if IS_VRS_OSS_CODE()
 
 bool PixelFrame::normalizeToPixelFormat(
-    shared_ptr<PixelFrame>& convertedFrame,
+    PixelFrame& convertedFrame,
     PixelFormat targetPixelFormat,
     const NormalizeOptions& options) const {
   return false;


### PR DESCRIPTION
Summary:
shared_ptr<PixelFrame> can look convenient, but it's heavier and riskier, in particular when multhreading is involved, as potential shared ownership (in particular accidental shared ownership) can make using/modifying objects unsafe. We don't have a good reason to use shared_ptr<PixelFrame> and as we're seeing apparent race conditions, unique_ptr<PixelFrame> is a better approach.
Note: this doesn't resolve the issue we're hunting down, but it closes one possible explanation.

Differential Revision: D68521262


