### PR TITLE
{Build} Add CMake support for OPUS build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,8 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
-            sudo apt-get update
-            sudo apt-get upgrade
+            sudo apt-get update -y
             sudo apt-get install -o Acquire::Retries=5 \
               cmake git ninja-build libgtest-dev libfmt-dev \
               libjpeg-dev libturbojpeg-dev libpng-dev \

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,6 +27,7 @@ jobs:
               libjpeg-dev libturbojpeg-dev libpng-dev \
               liblz4-dev libzstd-dev libxxhash-dev \
               libboost-system-dev libboost-filesystem-dev libboost-date-time-dev \
+              libopus-dev \
               qtbase5-dev portaudio19-dev
 
           elif [ "$RUNNER_OS" == "macOS" ]; then
@@ -34,6 +35,7 @@ jobs:
                   jpeg-turbo libpng \
                   lz4 zstd xxhash \
                   boost \
+                  opus \
                   qt5 portaudio
 
           else

--- a/cmake/FindOpus.cmake
+++ b/cmake/FindOpus.cmake
@@ -1,0 +1,44 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# - Find Opus
+# Find the Opus Interactive Audio Codec library
+#
+# Opus_INCLUDE_DIRS - where to find opus.h, etc.
+# Opus_LIBRARIES - List of libraries when using opus.
+# Opus_FOUND - True if Opus found.
+#
+# As this library is not mandatory, we set:
+# BUILD_WITH_OPUS to ON if found, OFF otherwise
+#
+
+find_path(Opus_INCLUDE_DIRS NAMES opus.h PATH_SUFFIXES opus)
+find_library(Opus_LIBRARIES NAMES opus)
+
+mark_as_advanced(Opus_LIBRARIES Opus_INCLUDE_DIRS)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Opus DEFAULT_MSG Opus_LIBRARIES Opus_INCLUDE_DIRS)
+
+if (Opus_FOUND AND NOT (TARGET Opus::opus))
+  add_library(Opus::opus UNKNOWN IMPORTED)
+  set_target_properties(Opus::opus
+    PROPERTIES
+      IMPORTED_LOCATION ${Opus_LIBRARIES}
+      INTERFACE_INCLUDE_DIRECTORIES ${Opus_INCLUDE_DIRS}
+  )
+  set(BUILD_WITH_OPUS ON)
+else ()
+  set(BUILD_WITH_OPUS OFF)
+endif()

--- a/cmake/LibrariesSetup.cmake
+++ b/cmake/LibrariesSetup.cmake
@@ -23,6 +23,7 @@ find_package(Boost REQUIRED
     date_time
     system
 )
+
 find_package(Threads REQUIRED)
 find_package(FmtLib REQUIRED)
 find_package(RapidjsonLib REQUIRED)
@@ -32,6 +33,10 @@ find_package(xxHash REQUIRED)
 find_package(PNG REQUIRED)
 find_package(JPEG REQUIRED)
 find_package(TurboJpeg REQUIRED)
+
+# Optional dependencies
+find_package(Opus)
+
 
 # Setup unit test infra, but only if unit tests are enabled
 if (UNIT_TESTS)

--- a/vrs/utils/AudioBlockOpus.cpp
+++ b/vrs/utils/AudioBlockOpus.cpp
@@ -17,8 +17,10 @@
 #include "AudioBlock.h"
 
 #ifdef OPUS_IS_AVAILABLE
+extern "C" {
 #include <opus.h>
 #include <opus_multistream.h>
+}
 #endif
 
 #define DEFAULT_LOG_CHANNEL "AudioBlockOpus"

--- a/vrs/utils/CMakeLists.txt
+++ b/vrs/utils/CMakeLists.txt
@@ -36,6 +36,12 @@ target_link_libraries(vrs_utils
     rapidjson::rapidjson
     vrs_logging
 )
+
+if (BUILD_WITH_OPUS)
+  target_link_libraries(vrs_utils PRIVATE Opus::opus)
+  target_compile_definitions(vrs_utils PRIVATE OPUS_IS_AVAILABLE)
+endif()
+
 target_include_directories(vrs_utils
   INTERFACE
     $<BUILD_INTERFACE:${VRS_SOURCE_DIR}>


### PR DESCRIPTION
Summary:
Enable optional OPUS compilation
- Add a CMake preprocessor `BUILD_WITH_OPUS`
- If required:
  - Add CMake rules to fetch OPUS library
  - Enable `OPUS_IS_AVAILABLE` CPP
- Update `pixi run build` to compile with OPUS support by default to ease CI and testing long term support of the feature

Differential Revision:
D68632323

Privacy Context Container: L1163201


