### PR TITLE
{Build} GitHub CI - remove apt-get upgrade

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,8 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
-            sudo apt-get update
-            sudo apt-get upgrade
+            sudo apt-get update -y
             sudo apt-get install -o Acquire::Retries=5 \
               cmake git ninja-build libgtest-dev libfmt-dev \
               libjpeg-dev libturbojpeg-dev libpng-dev \

--- a/vrs/utils/AudioBlockOpus.cpp
+++ b/vrs/utils/AudioBlockOpus.cpp
@@ -17,8 +17,10 @@
 #include "AudioBlock.h"
 
 #ifdef OPUS_IS_AVAILABLE
+extern "C" {
 #include <opus.h>
 #include <opus_multistream.h>
+}
 #endif
 
 #define DEFAULT_LOG_CHANNEL "AudioBlockOpus"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/projectaria_tools/pull/215

As we are running update and install libraries later, we don't need to run upgrade.

Differential Revision: D72653490


