### PR TITLE
Add support for boost::process v1.88.0

### DIFF
--- a/vrs/os/Process.h
+++ b/vrs/os/Process.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <vrs/os/Platform.h>
+
+#if IS_LINUX_PLATFORM() || IS_MAC_PLATFORM() || IS_WINDOWS_PLATFORM() || IS_ANDROID_PLATFORM()
+
+// Starting with boost 1.88.0, the default boost/process namespace is v2,
+// but the code in this file is still using v1, which is the only option ATM in
+// some environments. We can still use v1, but we need to include the v1 headers.
+
+#include <boost/version.hpp>
+
+#if BOOST_VERSION >= 108800
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/system.hpp>
+#if IS_WINDOWS_PLATFORM()
+#include <boost/process/v1/windows.hpp>
+#endif
+
+#else
+#include <boost/process.hpp>
+#include <boost/process/io.hpp>
+#include <boost/process/system.hpp>
+#if IS_WINDOWS_PLATFORM()
+#include <boost/process/windows.hpp>
+#endif
+#endif
+
+namespace vrs {
+namespace os {
+
+#if BOOST_VERSION >= 108800
+namespace process = boost::process::v1;
+#else
+namespace process = boost::process;
+#endif
+
+} // namespace os
+} // namespace vrs
+
+#endif // IS_LINUX_PLATFORM() || IS_MAC_PLATFORM() || IS_WINDOWS_PLATFORM()

--- a/vrs/test/helpers/TestProcess.h
+++ b/vrs/test/helpers/TestProcess.h
@@ -27,8 +27,7 @@
 
 #include <string>
 
-#include <boost/process/io.hpp>
-#include <boost/process/system.hpp>
+#include <vrs/os/Process.h>
 
 /// To test command line tools
 /// Add a definition for the location of the tool in the BUCK file, as an env variable.
@@ -37,7 +36,7 @@
 namespace vrs {
 namespace test {
 
-namespace bp = boost::process;
+namespace bp = vrs::os::process;
 
 class TestProcess {
  public:


### PR DESCRIPTION
Summary:
Boost/process has API breaking changes starting with version 1.88.0 created less than 2 weeks ago in open source and that brew is starting to offer. Starting with boost v1.88.0, process/v2 is the default.
We can't switch to process/v2, because we still need to support versions of boost that don't include any version of it. The good news is that boost 1.88.0 still includes process/v1, even if you have to go find it. The new <vrs/os/Process.h> header helps map the includes and definitions, so we can more easily continue to use boost/v1 until we can do a full switch to v2.

Differential Revision: D73412134


