### PR TITLE
Add Ocean installation via CMake in vrs repo.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,8 @@ jobs:
               liblz4-dev libzstd-dev libxxhash-dev \
               libboost-system-dev libboost-filesystem-dev libboost-date-time-dev \
               libopus-dev \
-              qtbase5-dev portaudio19-dev
+              qtbase5-dev portaudio19-dev \
+              libeigen3-dev
 
           elif [ "$RUNNER_OS" == "macOS" ]; then
               brew install cmake git ninja googletest glog fmt \
@@ -36,7 +37,8 @@ jobs:
                   lz4 zstd xxhash \
                   boost \
                   opus \
-                  qt5 portaudio
+                  qt5 portaudio \
+                  eigen
 
           else
               echo "$RUNNER_OS not supported"

--- a/cmake/FindOcean.cmake
+++ b/cmake/FindOcean.cmake
@@ -1,0 +1,96 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# FindOcean.cmake — fetch, build, and install Facebook Ocean as static libraries
+# Place this in a folder on CMAKE_MODULE_PATH (e.g. cmake/modules)
+
+# Prevent multiple inclusion
+if(Ocean_FOUND)
+  return()
+endif()
+
+# --------------------------
+# 0) Standard install dirs
+include(GNUInstallDirs)
+
+# --------------------------
+# 1) Fetch & build Ocean
+include(FetchContent)
+FetchContent_Declare(
+  ocean
+  GIT_REPOSITORY https://github.com/facebookresearch/ocean.git
+  GIT_TAG        origin/main
+)
+set(OCEAN_BUILD_MINIMAL ON CACHE BOOL "" FORCE)
+set(OCEAN_BUILD_TEST    OFF CACHE BOOL "" FORCE)
+message(STATUS "⤷ FetchContent: pulling and building Facebook Ocean…")
+FetchContent_MakeAvailable(ocean)
+
+# --------------------------
+# 2) Normalize component include dirs to avoid build-tree paths
+foreach(_lib IN ITEMS ocean_base ocean_cv ocean_math)
+  # Clear any pre-existing include dirs
+  set_target_properties(${_lib} PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES ""
+  )
+  # Add proper GENERATOR_EXPR-based includes
+  target_include_directories(${_lib} INTERFACE
+    $<BUILD_INTERFACE:${ocean_SOURCE_DIR}/impl>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  )
+endforeach()
+
+# --------------------------
+# 3) Bundle into a single INTERFACE target
+add_library(ocean INTERFACE)
+target_link_libraries(ocean INTERFACE
+  ocean_base
+  ocean_cv
+  ocean_math
+)
+add_library(Ocean::Ocean ALIAS ocean)
+
+# --------------------------
+# 4) Installation
+install(
+  TARGETS
+    ocean_base
+    ocean_cv
+    ocean_math
+    ocean
+  EXPORT OceanTargets
+  ARCHIVE      DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  INCLUDES     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(
+  DIRECTORY ${ocean_SOURCE_DIR}/impl/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  FILES_MATCHING PATTERN "*.h"
+)
+install(
+  EXPORT OceanTargets
+  FILE   FindOceanTargets.cmake
+  NAMESPACE Ocean::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Ocean
+)
+
+# --------------------------
+# 5) In-tree find_package support
+set(Ocean_FOUND     TRUE            CACHE INTERNAL "")
+set(Ocean_LIBRARIES Ocean::Ocean    CACHE INTERNAL "")
+set(Ocean_INCLUDE_DIRS "${ocean_SOURCE_DIR}/impl" CACHE INTERNAL "")
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Ocean
+  REQUIRED_VARS Ocean_LIBRARIES
+)

--- a/cmake/LibrariesSetup.cmake
+++ b/cmake/LibrariesSetup.cmake
@@ -36,7 +36,7 @@ find_package(TurboJpeg REQUIRED)
 
 # Optional dependencies
 find_package(Opus)
-
+find_package(Ocean)
 
 # Setup unit test infra, but only if unit tests are enabled
 if (UNIT_TESTS)

--- a/pixi.lock
+++ b/pixi.lock
@@ -18,6 +18,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.27.6-hcfe8598_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.6.0-h00ab1b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h00ab1b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-10.1.1-h00ab1b0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.3.0-h8d2909c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.3.0-he2b93b0_5.conda
@@ -103,6 +104,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-16.0.6-ha38d28d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-16.0.6-ha38d28d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.6.0-h7728843_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/eigen-3.4.0-h1c7c39f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-10.1.1-h7728843_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gtest-1.14.0-h1c7c39f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
@@ -179,6 +181,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-16.0.6-h3808999_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-16.0.6-h3808999_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.6.0-h2ffa867_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-3.4.0-h1995070_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-10.1.1-h2ffa867_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gtest-1.14.0-h1995070_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
@@ -242,6 +245,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.2.2-h56e8100_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cmake-3.27.6-hf0feee3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.6.0-h91493d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/eigen-3.4.0-h91493d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-10.1.1-h181d51b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gtest-1.14.0-h91493d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.0.0-h57928b3_49841.conda
@@ -880,6 +884,45 @@ packages:
   license: BSD
   size: 6421
   timestamp: 1689097764951
+- conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h00ab1b0_0.conda
+  sha256: 53b15a98aadbe0704479bacaf7a5618fcb32d1577be320630674574241639b34
+  md5: b1b879d6d093f55dd40d58b5eb2f0699
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1088433
+  timestamp: 1690272126173
+- conda: https://conda.anaconda.org/conda-forge/osx-64/eigen-3.4.0-h1c7c39f_0.conda
+  sha256: 187c0677e0cdcdc39aed716687a6290dd5b7f52b49eedaef2ed76be6cd0a5a3d
+  md5: 5b2cfc277e3d42d84a2a648825761156
+  depends:
+  - libcxx >=15.0.7
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1090184
+  timestamp: 1690272503232
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-3.4.0-h1995070_0.conda
+  sha256: c20b3677b16d8907343fce68e7c437184fef7f5ed0a765c104b775f8a485c5c9
+  md5: 3691ea3ff568ba38826389bafc717909
+  depends:
+  - libcxx >=15.0.7
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1087751
+  timestamp: 1690275869049
+- conda: https://conda.anaconda.org/conda-forge/win-64/eigen-3.4.0-h91493d7_0.conda
+  sha256: 633a6a8db1f9a010cb0619f3446fb61f62dea348b09615ffae9744ab1001c24c
+  md5: 305b3ca7023ac046b9a42a48661f6512
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1089706
+  timestamp: 1690273089254
 - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-10.1.1-h00ab1b0_1.conda
   sha256: 43ea9342de9f784c86bb01af75c7592a199bf249dcd81292eedc01242e0f471d
   md5: 50a08d74ca45785f3334b175da23fd82

--- a/pixi.toml
+++ b/pixi.toml
@@ -57,4 +57,5 @@ lz4 = "4.3.2.*"
 portaudio = "19.6.0.*"
 xxhash = "0.8.2"
 zlib = "1.2.13.*"
+eigen = "3.4.0"
 libopus = "1.4" # optional dependency

--- a/vrs/utils/CMakeLists.txt
+++ b/vrs/utils/CMakeLists.txt
@@ -16,6 +16,7 @@ add_subdirectory(converters)
 add_subdirectory(xxhash)
 add_subdirectory(cli)
 
+
 file (GLOB VRS_UTILS_SRCS *.cpp *.h *.hpp)
 # Remove fb-only source files (if there is still any lying around)
 file(GLOB VRS_UTILS_FB_SRCS *_fb.cpp *_fb.h)


### PR DESCRIPTION
Summary: This diff adds Ocean dependency to `VRS` repo via `CMake`'s FetchContent. It will automatically install Ocean within CMake. For now it installs the most recent main. I will change it to a stable hash later.

Differential Revision: D73552592


