### PR TITLE
Fixing FindOcean.cmake cannot run twice issue.

### DIFF
--- a/cmake/FindOcean.cmake
+++ b/cmake/FindOcean.cmake
@@ -32,8 +32,8 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/facebookresearch/ocean.git
   GIT_TAG        origin/main
 )
-set(OCEAN_BUILD_MINIMAL ON CACHE BOOL "" FORCE)
-set(OCEAN_BUILD_TEST    OFF CACHE BOOL "" FORCE)
+set(OCEAN_BUILD_MINIMAL ON)
+set(OCEAN_BUILD_TEST    OFF)
 message(STATUS "⤷ FetchContent: pulling and building Facebook Ocean…")
 FetchContent_MakeAvailable(ocean)
 
@@ -87,9 +87,9 @@ install(
 
 # --------------------------
 # 5) In-tree find_package support
-set(Ocean_FOUND     TRUE            CACHE INTERNAL "")
-set(Ocean_LIBRARIES Ocean::Ocean    CACHE INTERNAL "")
-set(Ocean_INCLUDE_DIRS "${ocean_SOURCE_DIR}/impl" CACHE INTERNAL "")
+set(Ocean_FOUND     TRUE)
+set(Ocean_LIBRARIES Ocean::Ocean)
+set(Ocean_INCLUDE_DIRS "${ocean_SOURCE_DIR}/impl")
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Ocean
   REQUIRED_VARS Ocean_LIBRARIES

--- a/pixi.toml
+++ b/pixi.toml
@@ -29,7 +29,7 @@ clean = { cmd = "rm -rf build" }
 print-env = { cmd = "echo $PATH" }
 prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=Release"
 build = { cmd = "cmake --build build --config Release --target all", depends-on = ["prepare"] }
-test = { cmd = "ctest -j --rerun-failed --output-on-failure ", cwd = "build", depends-on = ["clean", "build"]}
+test = { cmd = "ctest -j --rerun-failed --output-on-failure ", cwd = "build", depends-on = ["build"]}
 vrs = { cmd = "build/tools/vrs/vrs", depends-on = ["build"]}
 
 [target.win-64.tasks] # Deal with windows specifics (prepare and build)


### PR DESCRIPTION
Summary:
In D68536279, we ran into an issue where after introducing Ocean lib to vrs repo, running ` cmake -S . -B ./build/ -G Ninja ` multiple times would emit an error on `Ocean::Ocean` not found, we had to remove the `build/` directory in order to run it again. And we added a `clean` step in Pixi as a workaround of this issue. 

I found the root cause is because we cache some Ocean related variables in `FindOcean.cmake`, causing a second build to fail. This diff removed the cached variables that causes the issue.

Differential Revision: D74092912


