### PR TITLE
{Build} CI - Windows Github Infra migration

### DIFF
--- a/.github/workflows/build-and-test-pixi.yml
+++ b/.github/workflows/build-and-test-pixi.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest, ubuntu-latest, windows-2019] #macOS-13 is macIntel, macOS-latest is macSilicon
+        os: [macos-13, macos-latest, ubuntu-latest, windows-2022] #macOS-13 is macIntel, macOS-latest is macSilicon
     steps:
       - name : Setup repo
         uses: actions/checkout@v4

--- a/pixi.toml
+++ b/pixi.toml
@@ -34,7 +34,7 @@ vrs = { cmd = "build/tools/vrs/vrs", depends-on = ["build"]}
 
 [target.win-64.tasks] # Deal with windows specifics (prepare and build)
 cmake-generator = "cmake --help"
-prepare = "cmake -G 'Visual Studio 16 2019' -B build -S . -DCMAKE_BUILD_TYPE=Release"
+prepare = "cmake -B build -S . -DCMAKE_BUILD_TYPE=Release"
 build = { cmd = "cmake --build build --config Release  -- /m", depends-on = [
     "prepare",
 ] }


### PR DESCRIPTION
Summary: Update GitHub runner image "windows-2022" due to the removal of "windows-2019" following GitHub migration infra change https://github.com/actions/runner-images/issues/12045

Differential Revision: D77604363


