### PR TITLE
Clang-tidy last bits

### DIFF
--- a/sample_code/SampleRecordAndPlay.cpp
+++ b/sample_code/SampleRecordAndPlay.cpp
@@ -205,7 +205,7 @@ class RecordSample {
     XR_CHECK(result == 0);
 
     double lastTime = os::getTimestampSec();
-    while (recordable.iNeedToRecordMoreData()) {
+    while (vrs_sample_code::RecordableDemo::iNeedToRecordMoreData()) {
       recordable.createMoreRecords(); // for each recordable, maybe create new records of any type
       // maybe once every second, call:
       double now = os::getTimestampSec(); // current time using your *unique* time source

--- a/vrs/utils/test/JxlTest.cpp
+++ b/vrs/utils/test/JxlTest.cpp
@@ -19,7 +19,6 @@
 #endif
 #include <cmath>
 
-#include <numbers>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -110,7 +109,7 @@ void fill_in_row_jahne_grey16(
 }
 
 void FillInJahneTestPattern(PixelFrame& f) {
-  float frequency_coefficient = std::numbers::pi_v<float> / (2.0f * f.getWidth());
+  float frequency_coefficient = (float)(M_PI) / (2.0f * f.getWidth());
   float center_row_index = f.getHeight() / 2.0f;
   float center_col_index = f.getWidth() / 2.0f;
   float centered_row = 0.0f;


### PR DESCRIPTION
Summary: vscode makes it hard to ignore clang-tidy suggestions, many of which are new. Let's clean-up.

Differential Revision: D78497139


