### PR TITLE
Exposing xprs + ffmpeg libraries as PUBLIC in CMake.

### DIFF
--- a/vrs/AsyncDiskFileChunk.cpp
+++ b/vrs/AsyncDiskFileChunk.cpp
@@ -20,6 +20,8 @@
 
 #include <logging/Log.h>
 
+#include <algorithm>
+
 #include <vrs/helpers/EnumStringConverter.h>
 #include <vrs/helpers/FileMacros.h>
 #include <vrs/helpers/Strings.h>

--- a/vrs/utils/xprs/CMakeLists.txt
+++ b/vrs/utils/xprs/CMakeLists.txt
@@ -17,10 +17,10 @@ add_library(vrs_utils_xprs ${VRS_UTILS_XPRS_SRCS})
 target_link_libraries(vrs_utils_xprs
   PUBLIC
     vrs_utils
+    xprs
   PRIVATE
     vrs_logging
     vrs_os
-    xprs
     Ocean::Ocean
 )
 target_include_directories(vrs_utils_xprs

--- a/xprs/CMakeLists.txt
+++ b/xprs/CMakeLists.txt
@@ -24,9 +24,10 @@ if (ENABLE_NVCODEC)
 endif()
 
 target_link_libraries(xprs
+  PUBLIC
+    ffmpeg_decoding
   PRIVATE
     vrs_logging
-    ffmpeg_decoding
 )
 
 target_include_directories(xprs


### PR DESCRIPTION
Summary: This diff exposes the xprs and ffmpeg libraries as PUBLIC in CMake. This is needed by the Nebula ClientSDK project, where it needs to pybind some XPRS functions within projectaria_tools_gen2 in D79454506, and currently all XPRS + FFmpeg libs are not visible there, hence the build CI error in that diff.

Differential Revision: D80776108


