### PR TITLE
docusaurus components update

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -39,3 +39,11 @@ Some common defaults for linting/formatting have been set for you. If you integr
 ```
 $ yarn ci
 ```
+
+### Updating components when a security vulnerability is found
+
+If a security vulnerability is found in a component, you can update the version of the componens in the `package.json` file. If a component isn't listed already, you can add them in the "resolutions" section. Then run the following commands:
+
+```
+$ yarn install && yarn upgrade && yarn build
+```

--- a/website/package.json
+++ b/website/package.json
@@ -21,13 +21,15 @@
     "prettier:diff": "prettier --config .prettierrc --list-different \"**/*.{js,jsx,ts,tsx,md,mdx}\""
   },
   "dependencies": {
-    "@docusaurus/core": "^3.8.1",
-    "@docusaurus/preset-classic": "^3.8.1",
+    "@docusaurus/core": "3.8.1",
+    "@docusaurus/preset-classic": "3.8.1",
     "@mdx-js/react": "^3.1.0",
     "@svgr/webpack": "^8.1.0",
+    "@types/react": "^18.3.12",
     "clsx": "^2.1.1",
     "docusaurus-plugin-internaldocs-fb": "^1.19.2",
     "file-loader": "^6.2.0",
+    "mermaid": "^11.10.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "url-loader": "^4.1.1"
@@ -72,7 +74,6 @@
     "axios": "^1.8.3",
     "dompurify": "^3.2.4",
     "form-data": "^4.0.4",
-    "mermaid": "^11.10.0",
     "micromatch": "^4.0.8",
     "nth-check": ">=2.0.1",
     "on-headers": "^1.1.0",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1537,7 +1537,7 @@
     webpack "^5.95.0"
     webpackbar "^6.0.1"
 
-"@docusaurus/core@3.8.1", "@docusaurus/core@^3.8.1":
+"@docusaurus/core@3.8.1":
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-3.8.1.tgz#c22e47c16a22cb7d245306c64bc54083838ff3db"
   integrity sha512-ENB01IyQSqI2FLtOzqSI3qxG2B/jP4gQPahl2C3XReiLebcVh5B5cB9KYFvdoOqOWPyr5gXK4sjgTKv7peXCrA==
@@ -1791,7 +1791,7 @@
     tslib "^2.6.0"
     webpack "^5.88.1"
 
-"@docusaurus/preset-classic@^3.8.1":
+"@docusaurus/preset-classic@3.8.1":
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-3.8.1.tgz#bb79fd12f3211363720c569a526c7e24d3aa966b"
   integrity sha512-yJSjYNHXD8POMGc2mKQuj3ApPrN+eG0rO1UPgSx7jySpYU+n4WjBikbrA2ue5ad9A7aouEtMWUoiSRXTH/g7KQ==


### PR DESCRIPTION
Summary:
The docusuarus doc is broken in oss despite building internally.
This diff tries to address that.

Differential Revision:
D80831993

Privacy Context Container: L1181955


