### PR TITLE
Remove LittleEndian<T>

### DIFF
--- a/vrs/FileDetailsCache.cpp
+++ b/vrs/FileDetailsCache.cpp
@@ -49,11 +49,11 @@ struct DiskStreamId {
   explicit DiskStreamId(StreamId id)
       : typeId(static_cast<uint16_t>(id.getTypeId())), instanceId(id.getInstanceId()) {}
 
-  FileFormat::LittleEndian<uint16_t> typeId;
-  FileFormat::LittleEndian<uint16_t> instanceId;
+  uint16_t typeId;
+  uint16_t instanceId;
 
   RecordableTypeId getTypeId() const {
-    return static_cast<RecordableTypeId>(typeId());
+    return static_cast<RecordableTypeId>(typeId);
   }
 
   uint16_t getInstanceId() const {
@@ -74,13 +74,13 @@ struct DiskRecordInfo {
         streamId(record.streamId),
         recordType(static_cast<uint8_t>(record.recordType)) {}
 
-  FileFormat::LittleEndian<double> timestamp;
-  FileFormat::LittleEndian<int64_t> recordOffset;
+  double timestamp{};
+  int64_t recordOffset{};
   DiskStreamId streamId;
-  FileFormat::LittleEndian<uint8_t> recordType;
+  uint8_t recordType{};
 
   Record::Type getRecordType() const {
-    return static_cast<Record::Type>(recordType());
+    return static_cast<Record::Type>(recordType);
   }
 
   StreamId getStreamId() const {
@@ -176,8 +176,8 @@ int readIndexData(
     set<StreamId>& outStreamIds,
     vector<IndexRecord::RecordInfo>& outIndex,
     size_t indexSize) {
-  FileFormat::LittleEndian<uint32_t> recordableCount;
-  FileFormat::LittleEndian<uint32_t> diskIndexSize;
+  uint32_t recordableCount{};
+  uint32_t diskIndexSize{};
   if (!XR_VERIFY(indexSize >= sizeof(recordableCount))) {
     return FAILURE;
   }

--- a/vrs/FileFormat.cpp
+++ b/vrs/FileFormat.cpp
@@ -188,17 +188,12 @@ void RecordHeader::initDescriptionHeader(
   this->timestamp = Record::kMaxTimestamp;
 }
 
-template <typename ENUM, class LITTLEENDIAN>
-bool littleEndianIsValid_cast(LITTLEENDIAN& littleEndian) {
-  return enumIsValid_cast<ENUM>(littleEndian());
-}
-
 bool RecordHeader::isSanityCheckOk() const {
   if (!XR_VERIFY(recordSize >= sizeof(RecordHeader)) ||
       !XR_VERIFY(previousRecordSize == 0 || previousRecordSize >= sizeof(RecordHeader))) {
     return false;
   }
-  if (!XR_VERIFY(littleEndianIsValid_cast<Record::Type>(recordType))) {
+  if (!XR_VERIFY(enumIsValid_cast<Record::Type>(recordType))) {
     return false;
   }
   uint32_t uncompressedPayload = uncompressedSize; // doesn't include header already
@@ -213,7 +208,7 @@ bool RecordHeader::isSanityCheckOk() const {
         return false;
       }
     }
-    if (!XR_VERIFY(littleEndianIsValid_cast<CompressionType>(compressionType))) {
+    if (!XR_VERIFY(enumIsValid_cast<CompressionType>(compressionType))) {
       return false;
     }
   }

--- a/vrs/FileFormat.h
+++ b/vrs/FileFormat.h
@@ -56,48 +56,23 @@ namespace vrs {
 namespace FileFormat {
 #pragma pack(push, 1)
 
-/// \brief Placeholder layer for endianness support, if we ever need it.
-///
-/// All it currently does is enforce that we read & write native types through get & set methods.
-template <class T>
-class LittleEndian final {
- public:
-  LittleEndian() = default;
-  explicit LittleEndian(T value) : value_{value} {}
-
-  inline T operator()() const {
-    return value_;
-  }
-  inline operator T() const {
-    return value_;
-  }
-
-  inline LittleEndian& operator=(T value) {
-    value_ = value;
-    return *this;
-  }
-
- private:
-  T value_{};
-};
-
 /// Every file starts with this header, which may grow but not shrink!
 struct FileHeader {
-  LittleEndian<uint32_t> magicHeader1; ///< magic value #1
-  LittleEndian<uint32_t> magicHeader2; ///< magic value #2
-  LittleEndian<uint64_t> creationId; ///< A timestamp, hopefully unique, to match files (future).
-  LittleEndian<uint32_t> fileHeaderSize; ///< This header size, in bytes.
-  LittleEndian<uint32_t> recordHeaderSize; ///< Record headers' size, in bytes (same for all).
-  LittleEndian<int64_t> indexRecordOffset; ///< Index record offset in the whole file.
-  LittleEndian<int64_t> descriptionRecordOffset; ///< Description record offset in the whole file.
-  LittleEndian<int64_t>
-      firstUserRecordOffset; ///< Offset of the first user record in the file. If 0, the first
-                             ///< record is just after the description record (original behavior)
-  LittleEndian<uint64_t> future2; ///< For future use
-  LittleEndian<uint64_t> future3; ///< For future use
-  LittleEndian<uint64_t> future4; ///< For future use
-  LittleEndian<uint32_t> magicHeader3; ///< magic value #3
-  LittleEndian<uint32_t> fileFormatVersion; ///< file format version.
+  uint32_t magicHeader1{}; ///< magic value #1
+  uint32_t magicHeader2{}; ///< magic value #2
+  uint64_t creationId{}; ///< A timestamp, hopefully unique, to match files (future).
+  uint32_t fileHeaderSize{}; ///< This header size, in bytes.
+  uint32_t recordHeaderSize{}; ///< Record headers' size, in bytes (same for all).
+  int64_t indexRecordOffset{}; ///< Index record offset in the whole file.
+  int64_t descriptionRecordOffset{}; ///< Description record offset in the whole file.
+  int64_t
+      firstUserRecordOffset{}; ///< Offset of the first user record in the file. If 0, the first
+                               ///< record is just after the description record (original behavior)
+  uint64_t future2{}; ///< For future use
+  uint64_t future3{}; ///< For future use
+  uint64_t future4{}; ///< For future use
+  uint32_t magicHeader3{}; ///< magic value #3
+  uint32_t fileFormatVersion{}; ///< file format version.
 
   /// Initialize the structure's fixed values with default values for a regular VRS file.
   void init();
@@ -144,16 +119,15 @@ struct RecordHeader {
       uint32_t previousRecordSize,
       uint32_t recordSize,
       uint32_t uncompressedSize);
-  LittleEndian<uint32_t> recordSize; ///< byte count to the next record, header + data
-  LittleEndian<uint32_t> previousRecordSize; ///< byte count to the previous record, header + data
-  LittleEndian<int32_t> recordableTypeId; ///< record handler type id
-  LittleEndian<uint32_t> formatVersion; ///< data format version, as declared by the data producer
-  LittleEndian<double> timestamp; ///< record presentation time stamp
-  LittleEndian<uint16_t> recordableInstanceId; ///< record handle instance id
-  LittleEndian<uint8_t> recordType; ///< See Record::Type
-  LittleEndian<uint8_t> compressionType; ///< compression used, or 0 for none
-  LittleEndian<uint32_t>
-      uncompressedSize; ///< uncompressed payload size without header. 0 if not compressed.
+  uint32_t recordSize{}; ///< byte count to the next record, header + data
+  uint32_t previousRecordSize{}; ///< byte count to the previous record, header + data
+  int32_t recordableTypeId{}; ///< record handler type id
+  uint32_t formatVersion{}; ///< data format version, as declared by the data producer
+  double timestamp{}; ///< record presentation time stamp
+  uint16_t recordableInstanceId{}; ///< record handle instance id
+  uint8_t recordType{}; ///< See Record::Type
+  uint8_t compressionType{}; ///< compression used, or 0 for none
+  uint32_t uncompressedSize{}; ///< uncompressed payload size without header. 0 if not compressed.
 
   /// Set the record's type.
   /// @param type: Type of the record, as an enum.
@@ -164,7 +138,7 @@ struct RecordHeader {
   /// Get the record type, as an enum.
   /// @return The record type.
   inline Record::Type getRecordType() const {
-    return static_cast<Record::Type>(recordType());
+    return static_cast<Record::Type>(recordType);
   }
 
   /// Set the recordable type id for this record.
@@ -188,7 +162,7 @@ struct RecordHeader {
   /// Get the compression type used when writing the payload of this record.
   /// @return Compression type.
   inline CompressionType getCompressionType() const {
-    return static_cast<CompressionType>(compressionType());
+    return static_cast<CompressionType>(compressionType);
   }
 
   /// Set the compression type used when writing the payload of this record.

--- a/vrs/IndexRecord.h
+++ b/vrs/IndexRecord.h
@@ -55,8 +55,8 @@ struct DiskStreamId {
   explicit DiskStreamId(StreamId streamId)
       : typeId(static_cast<int32_t>(streamId.getTypeId())), instanceId(streamId.getInstanceId()) {}
 
-  FileFormat::LittleEndian<int32_t> typeId;
-  FileFormat::LittleEndian<uint16_t> instanceId;
+  int32_t typeId;
+  uint16_t instanceId;
 
   inline RecordableTypeId getTypeId() const {
     return FileFormat::readRecordableTypeId(typeId);
@@ -85,13 +85,13 @@ struct DiskRecordInfo {
         recordType(static_cast<uint8_t>(record->getRecordType())),
         streamId(streamId) {}
 
-  FileFormat::LittleEndian<double> timestamp;
-  FileFormat::LittleEndian<uint32_t> recordSize;
-  FileFormat::LittleEndian<uint8_t> recordType;
-  DiskStreamId streamId;
+  double timestamp{};
+  uint32_t recordSize{};
+  uint8_t recordType{};
+  DiskStreamId streamId{};
 
   inline Record::Type getRecordType() const {
-    return static_cast<Record::Type>(recordType());
+    return static_cast<Record::Type>(recordType);
   }
 
   inline StreamId getStreamId() const {


### PR DESCRIPTION
Summary:
All the systems vrs supports are little endian, and there are many other little endian dependencies all over the place that would be really difficult to remove. Therefore, we should not pretend that vrs could easily be made to work on a little endian system and the LittleEndian<T> class should be removed. This class also makes debugging more painful, as the values are all hidden in containers.

So everywhere `LittleEndian<T> variableName` is used, we replace it with a simple `T variableName`, then fix all the places variableName is used with direct manipulation of the member variable without going through any getter or setter. By adding operators in previous diff, we reduced the number of places where we still use getters to a very small number.

LittleEndian<T> used to default init its value, so we need to carefully init these variables to avoid introducing bugs.

Differential Revision: D83631395


