### PR TITLE
Fixing unreachable code return in vrs (#242)

### DIFF
--- a/vrs/utils/PixelFrame.cpp
+++ b/vrs/utils/PixelFrame.cpp
@@ -173,7 +173,6 @@ bool PixelFrame::readFrame(RecordReader* reader, const ContentBlock& cb) {
     default:
       return false;
   }
-  return false;
 }
 
 bool PixelFrame::readDiskImageData(RecordReader* reader, const ContentBlock& cb) {
@@ -284,7 +283,6 @@ bool PixelFrame::readCompressedFrame(const std::vector<uint8_t>& pixels, ImageFo
     default:
       return false;
   }
-  return false;
 }
 
 void PixelFrame::normalizeFrame(


### PR DESCRIPTION
Summary:

Addressing issues with `-Wunreachable-code-return`, which is currently enabled as a warning - our goal is to turn it on as an error by default. This catches dead code after a return statement or if/switch statement where all branches end in a return.

--

More context on this effort: https://fburl.com/clang-warnings-burndown
Dashboard: https://www.internalfb.com/unidash/dashboard/fbobjc_clang_warnings_burndown/tracker/?var_warning=clang-diagnostic-unreachable-code-return

Differential Revision: D97797194


