### PR TITLE
Fix Mac CI Qt5 discovery for ARM Homebrew runners (#243)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -59,7 +59,12 @@ jobs:
         shell: bash
         run: |
           if [ "$RUNNER_OS" == "macOS" ]; then
-              export QT_DIR=$(find /usr/local/Cellar/qt\@5 -name "5.*" -depth 1)
+              # Homebrew installs to /opt/homebrew on ARM, /usr/local on Intel
+              QT5_CELLAR="/opt/homebrew/Cellar/qt@5"
+              if [ ! -d "$QT5_CELLAR" ]; then
+                QT5_CELLAR="/usr/local/Cellar/qt@5"
+              fi
+              export QT_DIR=$(find "$QT5_CELLAR" -name "5.*" -depth 1 2>/dev/null)
           fi
           mkdir build
           cmake -S . -B build -G Ninja -DBUILD_WITH_XPRS:BOOL="${{ matrix.XPRS_FLAG }}"


### PR DESCRIPTION
Summary:

The build-and-test workflow hardcoded the Intel Homebrew path
(/usr/local/Cellar/qt@5) for QT_DIR, but macos-14 and macos-latest
runners are ARM where Homebrew installs to /opt/homebrew. This caused
CMake to find a partial Qt5 installation with broken mkspecs paths.

Search both ARM and Intel Homebrew prefixes so Qt5 is correctly
discovered on either architecture.

Differential Revision: D99775419
