### PR TITLE
Remove dependency on TSA

### DIFF
--- a/vrs/RecordManager.cpp
+++ b/vrs/RecordManager.cpp
@@ -18,7 +18,6 @@
 
 #include <algorithm>
 
-#include <thread_safety_analysis/Attributes.h>
 #include <vrs/Compressor.h>
 #include <vrs/DataSource.h>
 #include <vrs/FileFormat.h>
@@ -178,8 +177,7 @@ void RecordManager::purgeCache() {
   cache_.clear();
 }
 
-void RecordManager::collectOldRecords(double maxAge, list<Record*>& outCollectedRecords)
-    XR_TSA_NO_THREAD_SAFETY_ANALYSIS {
+void RecordManager::collectOldRecords(double maxAge, list<Record*>& outCollectedRecords) {
   outCollectedRecords.clear();
   lock_guard<mutex> guard{mutex_};
   if (!activeRecords_.empty()) {


### PR DESCRIPTION
Summary:
vrs is open source, and we don't use TSA there. Keep TSA out of vrs.
D108438305 broke vrs on github: https://github.com/facebookresearch/vrs/issues/247

Differential Revision: D108796925


