### PR TITLE
VRS cmake: fix fbsource build for rapidjson and Ocean (#249)

### DIFF
--- a/cmake/FindOcean.cmake
+++ b/cmake/FindOcean.cmake
@@ -24,18 +24,40 @@ endif()
 # 0) Standard install dirs
 include(GNUInstallDirs)
 
-# --------------------------
-# 1) Fetch & build Ocean
-include(FetchContent)
-FetchContent_Declare(
-  ocean
-  GIT_REPOSITORY https://github.com/facebookresearch/ocean.git
-  GIT_TAG        5fca1d27a9f37e868738b6db09a6b1e00723d80f # master branch, 2025.11.07
+# Try to find Ocean in fbsource tree first
+set(OCEAN_FBSOURCE_PATHS
+  "${VRS_SOURCE_DIR}/../../../xplat/ocean"
+  "${CMAKE_CURRENT_SOURCE_DIR}/../../../xplat/ocean"
+  "${CMAKE_SOURCE_DIR}/../../../xplat/ocean"
 )
-set(OCEAN_BUILD_MINIMAL ON)
-set(OCEAN_BUILD_TEST    OFF)
-message(STATUS "⤷ FetchContent: pulling and building Facebook Ocean…")
-FetchContent_MakeAvailable(ocean)
+foreach(ocean_path IN LISTS OCEAN_FBSOURCE_PATHS)
+  if(EXISTS "${ocean_path}/CMakeLists.txt")
+    set(OCEAN_SOURCE_DIR "${ocean_path}")
+    break()
+  endif()
+endforeach()
+
+if(OCEAN_SOURCE_DIR)
+  message(STATUS "Found Ocean in fbsource at ${OCEAN_SOURCE_DIR}")
+  set(OCEAN_BUILD_MINIMAL ON CACHE BOOL "" FORCE)
+  set(OCEAN_BUILD_TEST OFF CACHE BOOL "" FORCE)
+  # Ocean requires CMake 3.26, VRS requires 3.16 - allow higher version
+  add_subdirectory("${OCEAN_SOURCE_DIR}" "${CMAKE_BINARY_DIR}/ocean")
+  set(ocean_SOURCE_DIR "${OCEAN_SOURCE_DIR}")
+else()
+  # --------------------------
+  # 1) Fetch & build Ocean
+  include(FetchContent)
+  FetchContent_Declare(
+    ocean
+    GIT_REPOSITORY https://github.com/facebookresearch/ocean.git
+    GIT_TAG        5fca1d27a9f37e868738b6db09a6b1e00723d80f # master branch, 2025.11.07
+  )
+  set(OCEAN_BUILD_MINIMAL ON)
+  set(OCEAN_BUILD_TEST    OFF)
+  message(STATUS "⤷ FetchContent: pulling and building Facebook Ocean…")
+  FetchContent_MakeAvailable(ocean)
+endif()
 
 # --------------------------
 # 2) Normalize component include dirs to avoid build-tree paths

--- a/cmake/FindRapidjsonLib.cmake
+++ b/cmake/FindRapidjsonLib.cmake
@@ -15,22 +15,49 @@
 # The package version of rapidjson provided by apt on Linux or brew on Mac date from August 2016,
 # despite being the last official version (v1.1.0), and don't include important fixes.
 # So we get the code from GitHub at a known working state.
-find_path(RAPIDJSON_INSTALL NAMES rapidjson/rapidjson.h)
-if (RAPIDJSON_INSTALL)
-  message(WARNING "Found RapidJson at ${RAPIDJSON_INSTALL} It might be used instead "
-    "of VRS' version, and cause builds errors because the code is too old.")
-endif()
 
-set(RAPIDJSON_DIR "${EXTERNAL_DEPENDENCIES_DIR}/rapidjson")
-set(RAPIDJSON_INCLUDE_DIR "${RAPIDJSON_DIR}/include")
-set(RAPIDJSON_INCLUDE_FILE "${RAPIDJSON_INCLUDE_DIR}/rapidjson/rapidjson.h")
+# Try to find rapidjson in fbsource third-party (for fbsource builds)
+# Note: We intentionally do NOT search system paths here, because the system
+# rapidjson (v1.1.0 from 2016) is too old and causes build errors.
+# OSS builds will fall back to git clone below.
+find_path(RAPIDJSON_INCLUDE_DIR
+  NAMES rapidjson/rapidjson.h
+  HINTS
+    # fbsource third-party location
+    "${VRS_SOURCE_DIR}/../../../third-party/rapidjson/include"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/rapidjson/include"
+  NO_DEFAULT_PATH
+  NO_CMAKE_ENVIRONMENT_PATH
+  NO_CMAKE_SYSTEM_PATH
+)
 
-if (NOT EXISTS "${RAPIDJSON_INCLUDE_FILE}")
-  execute_process(COMMAND git clone https://github.com/Tencent/rapidjson.git "${RAPIDJSON_DIR}")
-endif()
-execute_process(COMMAND cd "${RAPIDJSON_DIR}" && git -f checkout a95e013b97ca6523f32da23f5095fcc9dd6067e5)
-if (NOT EXISTS "${RAPIDJSON_INCLUDE_FILE}")
-  message(FATAL_ERROR "Could not setup rapidjson external dependency at ${RAPIDJSON_DIR}")
+if (RAPIDJSON_INCLUDE_DIR)
+  message(STATUS "Found RapidJson at ${RAPIDJSON_INCLUDE_DIR}")
+  set(RAPIDJSON_FOUND TRUE)
+else()
+  # Fall back to downloading from GitHub (OSS behavior)
+  set(RAPIDJSON_DIR "${EXTERNAL_DEPENDENCIES_DIR}/rapidjson")
+  set(RAPIDJSON_INCLUDE_DIR "${RAPIDJSON_DIR}/include")
+  set(RAPIDJSON_INCLUDE_FILE "${RAPIDJSON_INCLUDE_DIR}/rapidjson/rapidjson.h")
+
+  if (NOT EXISTS "${RAPIDJSON_INCLUDE_FILE}")
+    execute_process(
+      COMMAND git clone https://github.com/Tencent/rapidjson.git "${RAPIDJSON_DIR}"
+      RESULT_VARIABLE GIT_CLONE_RESULT
+      ERROR_QUIET
+    )
+  endif()
+  if (EXISTS "${RAPIDJSON_DIR}")
+    execute_process(
+      COMMAND git -C "${RAPIDJSON_DIR}" checkout -f a95e013b97ca6523f32da23f5095fcc9dd6067e5
+      RESULT_VARIABLE GIT_CHECKOUT_RESULT
+      ERROR_QUIET
+    )
+  endif()
+  if (NOT EXISTS "${RAPIDJSON_INCLUDE_FILE}")
+    message(FATAL_ERROR "Could not setup rapidjson external dependency at ${RAPIDJSON_DIR}")
+  endif()
+  message(STATUS "Found RapidJson: ${RAPIDJSON_DIR}")
 endif()
 
 add_library(rapidjson::rapidjson INTERFACE IMPORTED)
@@ -38,6 +65,3 @@ set_target_properties(
   rapidjson::rapidjson PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${RAPIDJSON_INCLUDE_DIR}"
 )
-add_dependencies(rapidjson::rapidjson rapidjson)
-
-message(STATUS "Found RapidJson: ${RAPIDJSON_DIR}")


### PR DESCRIPTION
Summary:

Fix the VRS cmake build system to work in fbsource, while preserving OSS build compatibility.

- FindRapidjsonLib.cmake: Add fbsource third-party search path (${VRS_SOURCE_DIR}/../../../third-party/rapidjson/include) with NO_DEFAULT_PATH to avoid picking up old system rapidjson v1.1.0. Falls back to git clone for OSS builds. Remove bogus add_dependencies(rapidjson::rapidjson rapidjson) referencing non-existent target.

- FindOcean.cmake: Add fbsource xplat/ocean search path, build via add_subdirectory if found. Falls back to FetchContent from github for OSS builds.

This allows `cmake -S arvr/libraries/vrs -B build -G Ninja` to succeed in fbsource without internet access, using in-tree rapidjson and Ocean. Other dependencies (fmt, lz4, zstd, xxhash, etc.) are found via homebrew/system paths.

Differential Revision: D108821160


