### PR TITLE
Add a dav1d AV1 decoder backend (#250)

### DIFF
--- a/xprs/Codecs.h
+++ b/xprs/Codecs.h
@@ -42,5 +42,7 @@ constexpr std::string_view kNvH265DecoderName = "hevc_cuvid";
 constexpr std::string_view kNvAv1DecoderName = "av1_cuvid";
 constexpr std::string_view kVp9DecoderName = "vp9";
 constexpr std::string_view kAomDecoderName = "libaom-av1";
+// Served by xprs's own Dav1dVideoDecoder, not FFmpeg.
+constexpr std::string_view kDav1dDecoderName = "libdav1d";
 
 } // namespace xprs

--- a/xprs/xprsDecApi.cpp
+++ b/xprs/xprsDecApi.cpp
@@ -21,6 +21,10 @@
 #include <algorithm>
 #include <string_view>
 
+#ifdef WITH_DAV1D
+#include "Dav1dDecode.h"
+#endif
+
 #define DEFAULT_LOG_CHANNEL "XPRS"
 #include <logging/Log.h>
 
@@ -37,12 +41,24 @@ static const std::string_view kPreferredDecoderImplementations[] = {
 #if defined(HAS_VP9) && HAS_VP9 == 1
     kVp9DecoderName,
 #endif
+#ifdef WITH_DAV1D
+    // Prefer dav1d over libaom for AV1 whenever it is linked.
+    // Builds without WITH_DAV1D fall back to libaom.
+    kDav1dDecoderName,
+#endif
     kAomDecoderName,
 };
 
 namespace {
 
 bool findDecoderByName(const std::string_view& name, VideoCodec& codec) {
+#ifdef WITH_DAV1D
+  if (name == kDav1dDecoderName) {
+    codec = VideoCodec{VideoCodecFormat::AV1, kDav1dDecoderName.data(), false};
+    return true;
+  }
+#endif
+
   // Check ffmpeg first
   const AVCodec* avCodec = avcodec_find_decoder_by_name(name.data());
   if (avCodec != nullptr) {
@@ -102,7 +118,9 @@ XprsResult enumDecoders(CodecList& codecs, bool hwCapabilityCheck) {
     XR_LOGE("{}", convertExceptionToError(e, result));
   }
 
-  std::sort(codecs.begin(), codecs.end(), [](const VideoCodec& lhs, const VideoCodec& rhs) {
+  // stable_sort so decoders with equal hwAccel keep their
+  // kPreferredDecoderImplementations order (e.g. dav1d ahead of libaom for AV1).
+  std::stable_sort(codecs.begin(), codecs.end(), [](const VideoCodec& lhs, const VideoCodec& rhs) {
     return lhs.hwAccel > rhs.hwAccel;
   });
 
@@ -144,7 +162,9 @@ enumDecodersByFormat(CodecList& codecs, VideoCodecFormat standard, bool hwCapabi
     XR_LOGE("{}", convertExceptionToError(e, result));
   }
 
-  std::sort(codecs.begin(), codecs.end(), [](const VideoCodec& lhs, const VideoCodec& rhs) {
+  // stable_sort so decoders with equal hwAccel keep their
+  // kPreferredDecoderImplementations order (e.g. dav1d ahead of libaom for AV1).
+  std::stable_sort(codecs.begin(), codecs.end(), [](const VideoCodec& lhs, const VideoCodec& rhs) {
     return lhs.hwAccel > rhs.hwAccel;
   });
 
@@ -152,6 +172,11 @@ enumDecodersByFormat(CodecList& codecs, VideoCodecFormat standard, bool hwCapabi
 }
 
 IVideoDecoder* createDecoder(const VideoCodec& codec) {
+#ifdef WITH_DAV1D
+  if (codec.implementationName == kDav1dDecoderName) {
+    return new (std::nothrow) Dav1dVideoDecoder();
+  }
+#endif
   IVideoDecoder* result = new (std::nothrow) CVideoDecoder(codec);
   return result;
 }


### PR DESCRIPTION
Summary:

Adds `Dav1dVideoDecoder`, an `IVideoDecoder` backed by dav1d instead of FFmpeg/libaom. It decodes one AV1 access unit per `decodeFrame()` call (single-threaded, synchronous — matching xprs's per-frame contract) and hands out the decoded picture's planes with no copy. The AVX2 win comes from linking the asm-enabled `//third-party/libdav1d:libdav1d` (the diff below); the backend just calls `dav1d_open` / `dav1d_send_data` / `dav1d_get_picture`.

Wired into the xprs decoder factory behind `#ifdef WITH_DAV1D`, enabled only on the `:xprs` x86_64-Linux build via `-DWITH_DAV1D=1`; `xprs_oss`, ARM, and Apple targets are untouched.

Inert: `libdav1d` is enumerated and preferred, else will default AV1 decode to libaom.

Observed a 2x speed up in decoding using DAV1D thanks to the asm instructions

Reviewed By: cchang326, Dvad

Differential Revision: D109467496


