### PR TITLE
{Build} Fix fmt includes -- fmt 11 and forward

### DIFF
--- a/vrs/oss/logging/Checks.cpp
+++ b/vrs/oss/logging/Checks.cpp
@@ -19,7 +19,7 @@
 #include <cstdlib>
 
 #include <fmt/color.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <vrs/os/Platform.h>
 

--- a/vrs/oss/logging/Checks.h
+++ b/vrs/oss/logging/Checks.h
@@ -18,7 +18,9 @@
 
 #include <string>
 
-#include <fmt/core.h>
+// fmt/format.h (not core.h): the XR_CHECK* macros expand to fmt::format, which
+// fmt 11 moved out of core.h into format.h.
+#include <fmt/format.h>
 
 namespace vrs {
 

--- a/vrs/oss/logging/Log.h
+++ b/vrs/oss/logging/Log.h
@@ -18,7 +18,9 @@
 
 #include <string>
 
-#include <fmt/core.h>
+// fmt/format.h (not fmt/core.h) for fmt::format: fmt 11 turned core.h into a thin
+// base.h shim and moved fmt::format into format.h, which the XR_LOG* macros need.
+#include <fmt/format.h>
 
 namespace vrs {
 

--- a/vrs/oss/logging/Verify.h
+++ b/vrs/oss/logging/Verify.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <fmt/color.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #ifndef DEFAULT_LOG_CHANNEL
 #error "DEFAULT_LOG_CHANNEL must be defined before including <logging/Verify.h>"

--- a/vrs/utils/cli/CompressionBenchmark.cpp
+++ b/vrs/utils/cli/CompressionBenchmark.cpp
@@ -16,7 +16,7 @@
 
 #include <vrs/utils/cli/CompressionBenchmark.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <vrs/ErrorCode.h>
 #include <vrs/helpers/Strings.h>


### PR DESCRIPTION
Summary:
We have a new failure on CI for a include that most likely changes with fmt library version

```
FAILED: [code=1] vrs/helpers/CMakeFiles/vrs_helpers.dir/Throttler.cpp.o
/usr/bin/c++ -DFMT_SHARED -DOSS_BUILD_MODE -I/Users/runner/work/vrs/vrs -I/Users/runner/work/vrs/vrs/vrs/oss -isystem /opt/homebrew/include -isystem /Users/runner/work/vrs/vrs/build/external/rapidjson/include -O3 -DNDEBUG -std=c++17 -arch arm64 -fPIC -MD -MT vrs/helpers/CMakeFiles/vrs_helpers.dir/Throttler.cpp.o -MF vrs/helpers/CMakeFiles/vrs_helpers.dir/Throttler.cpp.o.d -o vrs/helpers/CMakeFiles/vrs_helpers.dir/Throttler.cpp.o -c /Users/runner/work/vrs/vrs/vrs/helpers/Throttler.cpp
/Users/runner/work/vrs/vrs/vrs/helpers/Throttler.cpp:39:7: error: no member named 'format' in namespace 'fmt'
   39 |       XR_LOGW(
      |       ^~~~~~~~
   40 |           "The following condition has happened {} times now, "
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   41 |           "so we will no longer report each new occurrence.",
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   42 |           stats.requestCounter);
      |           ~~~~~~~~~~~~~~~~~~~~~
/Users/runner/work/vrs/vrs/vrs/oss/logging/Log.h:62:22: note: expanded from macro 'XR_LOGW'
   62 | #define XR_LOGW(...) XR_LOG_DEFAULT(vrs::logging::Level::Warning, __VA_ARGS__)
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/runner/work/vrs/vrs/vrs/oss/logging/Log.h:55:73: note: expanded from macro 'XR_LOG_DEFAULT'
   55 | #define XR_LOG_DEFAULT(level, ...) log(level, DEFAULT_LOG_CHANNEL, fmt::format(__VA_ARGS__))
      |                                                                    ~~~~~^
/Users/runner/work/vrs/vrs/vrs/helpers/Throttler.cpp:44:7: error: no member named 'format' in namespace 'fmt'
   44 |       XR_LOGW(
      |       ^~~~~~~~
   45 |           "The following condition has happened {} times, and we no longer report each occurrence. "
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   46 |           "We skipped {} reports since the last one.",
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   47 |           stats.requestCounter,
      |           ~~~~~~~~~~~~~~~~~~~~~
   48 |           stats.skipSinceLastReport);
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/runner/work/vrs/vrs/vrs/oss/logging/Log.h:62:22: note: expanded from macro 'XR_LOGW'
   62 | #define XR_LOGW(...) XR_LOG_DEFAULT(vrs::logging::Level::Warning, __VA_ARGS__)
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/runner/work/vrs/vrs/vrs/oss/logging/Log.h:55:73: note: expanded from macro 'XR_LOG_DEFAULT'
   55 | #define XR_LOG_DEFAULT(level, ...) log(level, DEFAULT_LOG_CHANNEL, fmt::format(__VA_ARGS__))
      |                                                                    ~~~~~^
2 errors generated.
```


Including <fmt/format.h> is the most compatible way that will work for OLD and NEW versions.

- It's the portable choice because it's existed in every {fmt} release and has always declared fmt::format (it's the canonical header for the full formatting API).

Differential Revision: D109859743


