### PR TITLE
Fix VRS OSS macOS build: include <fmt/format.h> for fmt::format

### DIFF
--- a/vrs/oss/logging/Checks.h
+++ b/vrs/oss/logging/Checks.h
@@ -18,7 +18,7 @@
 
 #include <string>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace vrs {
 

--- a/vrs/oss/logging/Log.h
+++ b/vrs/oss/logging/Log.h
@@ -18,7 +18,7 @@
 
 #include <string>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace vrs {
 

--- a/vrs/oss/logging/Verify.h
+++ b/vrs/oss/logging/Verify.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <fmt/color.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #ifndef DEFAULT_LOG_CHANNEL
 #error "DEFAULT_LOG_CHANNEL must be defined before including <logging/Verify.h>"

--- a/vrs/utils/cli/CompressionBenchmark.cpp
+++ b/vrs/utils/cli/CompressionBenchmark.cpp
@@ -16,7 +16,7 @@
 
 #include <vrs/utils/cli/CompressionBenchmark.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <vrs/ErrorCode.h>
 #include <vrs/helpers/Strings.h>


### PR DESCRIPTION
Summary:
The VRS OSS GitHub CI (`Build VRS on macos-latest`, both `XPRS=OFF` and `XPRS=ON`) fails to compile with:

```
error: no member named 'format' in namespace 'fmt'
```

at every translation unit that uses the logging / check macros (first `vrs/helpers/Throttler.cpp` → `XR_LOGW`, then `vrs/DataSource.cpp` → `XR_DEV_CHECK_GT`, etc.).

The logging headers define their macros in terms of `fmt::format(...)` but only include `<fmt/core.h>`. `fmt::format` is declared in `<fmt/format.h>`. This compiled before only because older `{fmt}` releases happened to pull `format` in transitively via `core.h`. Homebrew on `macos-latest` recently upgraded `{fmt}` to 11.x, where the headers were reorganized (`core.h` is now a deprecated shim and no longer drags in the `format` definition), so the symbol is no longer visible. This is environment-driven — no VRS source change triggered it — which is why a previously-green build started failing this week, and why it is independent of the `XPRS` flag (both matrix legs break identically).

Switch the include to `<fmt/format.h>` (which transitively includes `core.h`/`base.h`) in every VRS OSS file that calls `fmt::format` but only included `<fmt/core.h>`:
- `vrs/oss/logging/Log.h`
- `vrs/oss/logging/Checks.h`
- `vrs/oss/logging/Verify.h`
- `vrs/utils/cli/CompressionBenchmark.cpp`

This makes each header/TU self-contained against the function it actually calls, independent of the `{fmt}` version.

Differential Revision: D109906400


