### PR TITLE
isolate Recordable instance-id counter storage

### DIFF
--- a/vrs/Recordable.cpp
+++ b/vrs/Recordable.cpp
@@ -22,6 +22,7 @@
 
 #include <vrs/DataLayout.h>
 #include <vrs/RecordFormat.h>
+#include <vrs/RecordableInstanceIdStorage.h>
 #include <vrs/os/System.h>
 
 using namespace std;
@@ -74,24 +75,16 @@ void Recordable::addTags(const StreamTags& tags) {
   }
 }
 
-static recursive_mutex& getInstanceIdMutex() {
-  static recursive_mutex sMutex;
-  return sMutex;
-}
-
-static map<RecordableTypeId, uint16_t>& getInstanceIds() {
-  static map<RecordableTypeId, uint16_t> sInstanceIds;
-  return sInstanceIds;
-}
-
 void Recordable::resetNewInstanceIds() {
+  // NOLINTNEXTLINE(facebook-thread-safety-analysis)
   unique_lock<recursive_mutex> guard{getInstanceIdMutex()};
-  getInstanceIds().clear();
+  getInstanceIdMap().clear();
 }
 
 uint16_t Recordable::getNewInstanceId(RecordableTypeId typeId) {
+  // NOLINTNEXTLINE(facebook-thread-safety-analysis)
   unique_lock<recursive_mutex> guard{getInstanceIdMutex()};
-  map<RecordableTypeId, uint16_t>& instanceIds = getInstanceIds();
+  map<RecordableTypeId, uint16_t>& instanceIds = getInstanceIdMap();
   uint16_t instanceId = 1; // default instance Id
   auto newId = instanceIds.find(typeId);
   if (newId == instanceIds.end()) {
@@ -113,11 +106,11 @@ const string& Recordable::getTag(const map<string, string>& tags, const string& 
 
 TemporaryRecordableInstanceIdsResetter::TemporaryRecordableInstanceIdsResetter()
     : lock_{getInstanceIdMutex()} {
-  preservedState_.swap(getInstanceIds());
+  preservedState_.swap(getInstanceIdMap());
 }
 
 TemporaryRecordableInstanceIdsResetter::~TemporaryRecordableInstanceIdsResetter() {
-  preservedState_.swap(getInstanceIds());
+  preservedState_.swap(getInstanceIdMap());
 }
 
 } // namespace vrs

--- a/vrs/RecordableInstanceIdStorage.cpp
+++ b/vrs/RecordableInstanceIdStorage.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <vrs/RecordableInstanceIdStorage.h>
+
+using namespace std;
+
+namespace vrs {
+
+recursive_mutex& getInstanceIdMutex() {
+  // NOLINTNEXTLINE(facebook-thread-safety-analysis)
+  static recursive_mutex sMutex;
+  return sMutex;
+}
+
+map<RecordableTypeId, uint16_t>& getInstanceIdMap() {
+  static map<RecordableTypeId, uint16_t> sInstanceIds;
+  return sInstanceIds;
+}
+
+} // namespace vrs

--- a/vrs/RecordableInstanceIdStorage.h
+++ b/vrs/RecordableInstanceIdStorage.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <mutex>
+
+#include <vrs/StreamId.h>
+#include <vrs/os/Platform.h>
+
+// The instance-id counter that backs Recordable::getNewInstanceId() lives behind these accessors so
+// it can be linked as either a static archive or a single shared library. When the same process
+// statically links VRS into several shared libraries, routing every copy of the allocation logic to
+// one shared definition of this counter keeps Recordable StreamIds unique process-wide. Only the
+// accessors are exported; the counter itself stays internal to the owning translation unit.
+#if IS_WINDOWS_PLATFORM()
+#if defined(VRS_INSTANCE_ID_SHARED_BUILD)
+#define VRS_INSTANCE_ID_API __declspec(dllexport)
+#else
+#define VRS_INSTANCE_ID_API
+#endif
+#else
+#define VRS_INSTANCE_ID_API __attribute__((visibility("default")))
+#endif
+
+namespace vrs {
+
+/// Mutex guarding the process instance-id counter; shared by every copy of the allocation logic.
+VRS_INSTANCE_ID_API std::recursive_mutex& getInstanceIdMutex();
+
+/// The per-RecordableTypeId instance-id counter. Access only while holding getInstanceIdMutex().
+VRS_INSTANCE_ID_API std::map<RecordableTypeId, uint16_t>& getInstanceIdMap();
+
+} // namespace vrs


### PR DESCRIPTION
Summary:
> ⚠️ **Known issue (fbcode):** as submitted, this diff breaks fbcode-mode VRS consumers — fbcode shared-links `vrs_core` standalone under `-z defs`, and its instance-id accessor symbols (`vrs::getInstanceIdMutex()`/`getInstanceIdMap()`) are undefined because the storage is a separate target. arvr hides this via static absorption, so it passes locally. Diagnosis + two fix options (recommend pivoting to a self-contained minimal-injection design): **P2401385674**.

 ---

This stack fixes cross-shared-library `StreamId` collisions in VRS without the runtime install contract of the injected-allocator approach. The `Recordable` instance-id counter is a function-local static in `Recordable.cpp`; when VRS is statically linked into several `.so`s in one process, each `.so` gets its own copy of the counter, so two `Recordable`s created in different libraries can be assigned the same `{typeId, instanceId}`. `RecordFileWriter::addRecordable()` then silently drops the second and a stream goes missing from the output with no error.

This diff isolates only the backing storage — the counter `map` and its `recursive_mutex` — into a new translation unit `RecordableInstanceIdStorage.{h,cpp}` exposing `getInstanceIdMap()` / `getInstanceIdMutex()`. The allocation logic stays in `Recordable.cpp`. The storage builds two ways: `recordable_instance_id_storage_static` (`oxx_static_library`) and `recordable_instance_id_storage` (`oxx_shared_library`, exporting only the two accessors via `VRS_INSTANCE_ID_API`, with `-fvisibility=hidden` + `-Wl,--exclude-libs,ALL` keeping absorbed deps out of `.dynsym`). `vrs_core` is the rest of VRS minus the storage TU; the public `:vrs` target is now `vrs_core` + the static storage, so a single-binary build absorbs exactly one copy and behavior is unchanged. A later diff routes gravity through the shared storage variant so the counter stays unique across plugin `.so`s.

Full design / 3-way comparison: P2401093338.

Differential Revision: D110109452
