### PR TITLE
{CUDA Decoding} Gate NVDEC sources in OSS CMake so default GitHub build passes (#255)

### DIFF
--- a/xprs/CMakeLists.txt
+++ b/xprs/CMakeLists.txt
@@ -13,14 +13,63 @@
 # limitations under the License.
 
 
-file(GLOB XPRS_SRCS *.cpp *.h *.hpp)
-add_library(xprs ${XPRS_SRCS})
+# Base sources (always built). Explicit list rather than file(GLOB) so the
+# NVDEC/CUDA sources (nvDecoder.cpp, cudaContextProvider.cpp) are not compiled
+# unconditionally: they need nv-codec-headers (ffnvcodec) at build time and an
+# NVIDIA driver at runtime, so the default OSS build (ENABLE_NVCODEC=OFF) must
+# leave them out. Only the files synced to OSS by vrs.cconf are listed.
+#
+# DECODER-ONLY: the OSS distribution ships only the decode path. The encoder
+# sources (nvEncoder.cpp, FFmpegEncode, etc.) depend on internal-only headers
+# that are not synced to OSS; xprsEncZero.cpp is the no-op encoder stub that
+# lets the library link without them.
+set(XPRS_SRCS
+  FFmpegDecode.cpp
+  FFmpegUtils.cpp
+  xprsBase.cpp
+  xprsDecApi.cpp
+  xprsDecoder.cpp
+  xprsEncZero.cpp
+  xprsUtils.cpp
+)
+
+# Headers — kept in the library for IDE/install visibility.
+set(XPRS_HEADERS
+  Codecs.h
+  FFmpegDecode.h
+  FFmpegUtils.h
+  Final.h
+  InternalDecoder.h
+  xprs.h
+  xprsDecoder.h
+  xprsUtils.h
+)
+
+# NVDEC/CUDA decode sources (only when ENABLE_NVCODEC=ON).
+set(XPRS_NVCODEC_SRCS
+  nvDecoder.cpp
+  cudaContextProvider.cpp
+)
+
+option(ENABLE_NVCODEC "Enable NVIDIA CUVID/NVDEC GPU-accelerated H.265 decode" OFF)
+
+if (ENABLE_NVCODEC)
+  list(APPEND XPRS_SRCS ${XPRS_NVCODEC_SRCS})
+  list(APPEND XPRS_HEADERS
+    cudaContextProvider.h
+    cudaUtils.h
+    nvDecoder.h
+  )
+endif()
+
+add_library(xprs ${XPRS_SRCS} ${XPRS_HEADERS})
 set(XPRS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
-# option for turn on / off HW decoder
-option(ENABLE_NVCODEC "Enable NVCodec support" OFF)
 if (ENABLE_NVCODEC)
-  target_compile_options(xprs PRIVATE WITH_NVCODEC)
+  target_compile_definitions(xprs PRIVATE WITH_NVCODEC=1)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(FFNVCODEC REQUIRED IMPORTED_TARGET ffnvcodec)
+  target_link_libraries(xprs PRIVATE PkgConfig::FFNVCODEC)
 endif()
 
 target_link_libraries(xprs


### PR DESCRIPTION
Summary:

The OSS ShipIt sync now exports the xprs CUDA decoder sources (`nvDecoder.cpp`, `cudaContextProvider.cpp`, and their headers) to the `facebookresearch/vrs` GitHub mirror. But `xprs/CMakeLists.txt` still uses `file(GLOB *.cpp)`, so the default OSS build (`ENABLE_NVCODEC=OFF`, no `nv-codec-headers` installed) compiles those files unconditionally and fails:

    fatal error: 'ffnvcodec/dynlink_cuda.h' file not found

seen on the macOS and Ubuntu `Build VRS` jobs (Windows is unaffected because OSS VRS only builds xprs on Linux/macOS).

Fix: exclude the NVDEC/CUDA sources from the globbed source list and add them back only under `ENABLE_NVCODEC=ON`, where `nv-codec-headers` (`ffnvcodec`) is required and `WITH_NVCODEC` is defined. This restores the known-good decoder-only default build while keeping the GPU path available when explicitly enabled. Also fixes the pre-existing `target_compile_options(... WITH_NVCODEC)` (a silent no-op) to `target_compile_definitions(... WITH_NVCODEC=1)`.

This is the minimal unblock for the red GitHub CI; it is a subset of the larger CUDA CMake rework in the review stack (D103253721), which can drop this hunk once landed.

Differential Revision: D113160661


