### PR TITLE
{CUDA Decoding} Add NvCodecConfig.h, migrate WITH_NVCODEC guards to XPRS_HAS_NVDEC/XPRS_HAS_NVENC (#259)

### DIFF
--- a/xprs/Codecs.h
+++ b/xprs/Codecs.h
@@ -18,9 +18,11 @@
 
 #include <string_view>
 
-#ifdef WITH_NVCODEC
-#include "nvEncoder.h"
-#endif
+// Note: nvEncoder.h is intentionally NOT included here. Earlier versions of
+// this header pulled it in under WITH_NVCODEC, but the only consumers
+// (xprsEncApi.cpp, xprsEncoder.cpp, test/xprs_gtest_common.h) include
+// nvEncoder.h directly. Removing it here lets Codecs.h stay free of the
+// XPRS_HAS_NVENC guard.
 
 namespace xprs {
 

--- a/xprs/NvCodecConfig.h
+++ b/xprs/NvCodecConfig.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// Single source of truth for NVIDIA codec compilation guards.
+//
+// `WITH_NVCODEC` is the build-system flag (Buck preprocessor flag, CMake
+// `option(ENABLE_NVCODEC ...)`). Source files should use the self-documenting
+// macros below instead of `WITH_NVCODEC` so it's clear at the call site
+// whether the gated code requires NVDEC (decode), NVENC (encode), or both.
+//
+// Both macros are defined together when WITH_NVCODEC is set. The split into
+// separate macros prepares for build configurations that ship only one half
+// (e.g., OSS distributions that include NVDEC but omit NVENC due to driver,
+// hardware, or licensing constraints).
+
+#ifdef WITH_NVCODEC
+#define XPRS_HAS_NVDEC
+#define XPRS_HAS_NVENC
+#endif

--- a/xprs/cudaContextProvider.cpp
+++ b/xprs/cudaContextProvider.cpp
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
+// DEFAULT_LOG_CHANNEL must be defined before "logging/Log.h": the OSS build's
+// XR_LOGE/XR_LOGW macros are gated on it (the internal logging header defines
+// them unconditionally, which is why this ordering bug is invisible to the Buck
+// build but breaks the OSS CMake build).
+#define DEFAULT_LOG_CHANNEL "XPRS"
+
 #include "cudaContextProvider.h"
 
 #include "logging/Log.h"
-#define DEFAULT_LOG_CHANNEL "XPRS"
 
 namespace xprs {
 
@@ -49,23 +54,27 @@ NvCodecContext NvCodecContextProvider::getNvCodecContext(const int device_num) {
     return nv_codec_context;
   }
 
+  // Note: all failures in this function below log at WARN, not ERROR. The only caller
+  // (xprsDecApi.cpp::enumDecoders) catches the throw and falls back to SW
+  // decoders. On a non-GPU machine this fires every VRS file open, so logging
+  // ERROR-level would spam users who never asked for GPU decoding.
   int ret = cuda_load_functions(&nv_codec_context._cuda_functions, nullptr);
   if (ret < 0) {
     const std::string message = "Loading CUDA functions failed";
-    XR_LOGE("{}", message.c_str());
+    XR_LOGW("{}", message.c_str());
     throw std::runtime_error(message);
   }
   ret = cuvid_load_functions(&nv_codec_context._cuvid_functions, nullptr);
   if (ret < 0) {
     const std::string message = "Loading nvcuvid functions failed";
-    XR_LOGE("{}", message.c_str());
+    XR_LOGW("{}", message.c_str());
     throw std::runtime_error(message);
   }
 
   CUresult cu_result = nv_codec_context._cuda_functions->cuInit(0);
   if (cu_result != CUDA_SUCCESS) {
     const std::string message = "cuInit failed with error code: " + std::to_string(cu_result);
-    XR_LOGE("{}", message.c_str());
+    XR_LOGW("{}", message.c_str());
     throw std::runtime_error(message);
   }
 
@@ -73,7 +82,7 @@ NvCodecContext NvCodecContextProvider::getNvCodecContext(const int device_num) {
   cu_result = nv_codec_context._cuda_functions->cuDeviceGet(&cuda_device, device_num);
   if (cu_result != CUDA_SUCCESS) {
     const std::string message = "cuDeviceGet failed with error code: " + std::to_string(cu_result);
-    XR_LOGE("{}", message.c_str());
+    XR_LOGW("{}", message.c_str());
     throw std::runtime_error(message);
   }
 
@@ -82,7 +91,7 @@ NvCodecContext NvCodecContextProvider::getNvCodecContext(const int device_num) {
   if (cu_result != CUDA_SUCCESS) {
     const std::string message =
         "cuDeviceGetName failed with error code: " + std::to_string(cu_result);
-    XR_LOGE("{}", message.c_str());
+    XR_LOGW("{}", message.c_str());
     throw std::runtime_error(message);
   }
 
@@ -90,7 +99,7 @@ NvCodecContext NvCodecContextProvider::getNvCodecContext(const int device_num) {
       &nv_codec_context._cucontext, CU_CTX_SCHED_BLOCKING_SYNC, cuda_device);
   if (cu_result != CUDA_SUCCESS) {
     const std::string message = "cuCtxCreate failed with error code: " + std::to_string(cu_result);
-    XR_LOGE("{}", message.c_str());
+    XR_LOGW("{}", message.c_str());
     throw std::runtime_error(message);
   }
 
@@ -99,7 +108,7 @@ NvCodecContext NvCodecContextProvider::getNvCodecContext(const int device_num) {
   if (cu_result != CUDA_SUCCESS) {
     const std::string message =
         "cuCtxPopCurrent failed with error code: " + std::to_string(cu_result);
-    XR_LOGE("{}", message.c_str());
+    XR_LOGW("{}", message.c_str());
     throw std::runtime_error(message);
   }
 

--- a/xprs/nvDecoder.cpp
+++ b/xprs/nvDecoder.cpp
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+// DEFAULT_LOG_CHANNEL must be defined before <logging/Log.h>: the OSS build's
+// XR_LOGE/XR_LOGW/XR_LOGI macros are gated on it (the internal logging header
+// defines them unconditionally, which is why this ordering bug is invisible to
+// the Buck build but breaks the OSS CMake build).
+#define DEFAULT_LOG_CHANNEL "XPRS"
+
 #include "nvDecoder.h"
 #include "Codecs.h"
 #include "FFmpegUtils.h"
@@ -22,10 +28,9 @@
 
 #include <logging/Log.h>
 #include <cmath>
+#include <memory>
 #include <stdexcept>
 #include <string>
-
-#define DEFAULT_LOG_CHANNEL "XPRS"
 
 namespace xprs {
 
@@ -167,6 +172,44 @@ int NvDecoder::HandleVideoSequence(CUVIDEOFORMAT* vdeo_format) {
   _decoded_image_yuv.resize(size_ofdecoded_image_yuv_format_in_bytes);
 
   CUDAContextScope cuda_context_scope(_nvcodec_context);
+
+  // Capability pre-check (NVIDIA-recommended): NVDEC hardware does not support
+  // every codec/chroma/bit-depth/resolution combination. Most notably it cannot
+  // decode monochrome (4:0:0) H.265 — used by Aria's grayscale SLAM and eye
+  // cameras — and returns CUDA_ERROR_NOT_SUPPORTED from cuvidCreateDecoder.
+  // Querying cuvidGetDecoderCaps first lets such streams fall back to SW decode
+  // with a single clear log line, instead of emitting alarming CUDA error logs
+  // for an entirely expected condition. cuvidGetDecoderCaps is loaded optionally
+  // by nv-codec-headers, so guard against a null function pointer.
+  if (_nvcodec_context._cuvid_functions->cuvidGetDecoderCaps != nullptr) {
+    CUVIDDECODECAPS decode_caps = {};
+    decode_caps.eCodecType = video_decode_create_info.CodecType;
+    decode_caps.eChromaFormat = video_decode_create_info.ChromaFormat;
+    decode_caps.nBitDepthMinus8 = video_decode_create_info.bitDepthMinus8;
+    // Only a *successful* caps query that reports the format unsupported (or out
+    // of the supported size range) forces SW fallback. If the query itself fails
+    // (transient driver/context issue), fall through to cuvidCreateDecoder and
+    // let it surface the real error rather than permanently disabling NVDEC.
+    if (_nvcodec_context._cuvid_functions->cuvidGetDecoderCaps(&decode_caps) == CUDA_SUCCESS) {
+      const unsigned long width = video_decode_create_info.ulWidth;
+      const unsigned long height = video_decode_create_info.ulHeight;
+      const bool unsupported = !decode_caps.bIsSupported ||
+          width < static_cast<unsigned long>(decode_caps.nMinWidth) ||
+          height < static_cast<unsigned long>(decode_caps.nMinHeight) ||
+          width > static_cast<unsigned long>(decode_caps.nMaxWidth) ||
+          height > static_cast<unsigned long>(decode_caps.nMaxHeight);
+      if (unsupported) {
+        XR_LOGW(
+            "NVDEC does not support this stream (chroma_format={}, bit_depth={}, {}x{}); falling back to SW decode",
+            static_cast<int>(video_decode_create_info.ChromaFormat),
+            static_cast<int>(video_decode_create_info.bitDepthMinus8) + 8,
+            width,
+            height);
+        throw std::runtime_error("NVDEC unsupported stream format; using SW decode");
+      }
+    }
+  }
+
   CUDA_API_CALL(
       _nvcodec_context._cuvid_functions->cuvidCreateDecoder(&_decoder, &video_decode_create_info),
       _nvcodec_context._cuda_functions,

--- a/xprs/xprsDecApi.cpp
+++ b/xprs/xprsDecApi.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "Codecs.h"
+#include "NvCodecConfig.h"
 #include "xprsDecoder.h"
 #include "xprsUtils.h"
 
@@ -34,7 +35,7 @@ namespace xprs {
 static const std::string_view kPreferredDecoderImplementations[] = {
     kH265DecoderName,
     kH264DecoderName,
-#ifdef WITH_NVCODEC
+#ifdef XPRS_HAS_NVDEC
     kNvH264DecoderName,
     kNvH265DecoderName,
     kNvAv1DecoderName,
@@ -68,7 +69,7 @@ bool findDecoderByName(const std::string_view& name, VideoCodec& codec) {
   }
 
   // Add custom decoders
-#ifdef WITH_NVCODEC
+#ifdef XPRS_HAS_NVDEC
   if (name == kNvH265DecoderName) {
     codec = VideoCodec{VideoCodecFormat::H265, name.data(), true};
     return true;
@@ -116,7 +117,7 @@ XprsResult enumDecoders(CodecList& codecs, bool hwCapabilityCheck) {
           continue;
         }
         if (codec.hwAccel && hwCapabilityCheck) {
-#ifdef WITH_NVCODEC
+#ifdef XPRS_HAS_NVDEC
           const NvCodecContext nvcodecContext = NvCodecContextProvider::getNvCodecContext();
           if (deviceHasNoHwDecoder(codec.implementationName, nvcodecContext._device_name)) {
             XR_LOGI(
@@ -168,7 +169,7 @@ enumDecodersByFormat(CodecList& codecs, VideoCodecFormat standard, bool hwCapabi
             continue;
           }
           if (codec.hwAccel && hwCapabilityCheck) {
-#ifdef WITH_NVCODEC
+#ifdef XPRS_HAS_NVDEC
             const NvCodecContext nvcodecContext = NvCodecContextProvider::getNvCodecContext();
             if (deviceHasNoHwDecoder(codec.implementationName, nvcodecContext._device_name)) {
               XR_LOGI(

--- a/xprs/xprsDecApi.cpp
+++ b/xprs/xprsDecApi.cpp
@@ -19,6 +19,7 @@
 #include "xprsUtils.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <string_view>
 
 #ifdef WITH_DAV1D
@@ -85,6 +86,15 @@ bool findDecoderByName(const std::string_view& name, VideoCodec& codec) {
   return false;
 }
 
+// Set XPRS_DISABLE_HW_DECODE to any value to force CPU-only decoding. Useful
+// for deterministic results, working around GPU memory pressure, or comparing
+// HW-vs-SW output. Read once at first call so the value is fixed for the
+// process lifetime — runtime mutation of the env var has no effect.
+bool isHwDecodeDisabled() {
+  static const bool disabled = std::getenv("XPRS_DISABLE_HW_DECODE") != nullptr;
+  return disabled;
+}
+
 } // namespace
 
 ///
@@ -95,10 +105,16 @@ XprsResult enumDecoders(CodecList& codecs, bool hwCapabilityCheck) {
 
   codecs.clear();
   codecs.reserve(std::size(kPreferredDecoderImplementations));
+  const bool hwDisabled = isHwDecodeDisabled();
   try {
     for (const auto& impl : kPreferredDecoderImplementations) {
       VideoCodec codec;
       if (findDecoderByName(impl, codec)) {
+        if (codec.hwAccel && hwDisabled) {
+          XR_LOGI(
+              "Skipping HW decoder {} (XPRS_DISABLE_HW_DECODE is set)", codec.implementationName);
+          continue;
+        }
         if (codec.hwAccel && hwCapabilityCheck) {
 #ifdef WITH_NVCODEC
           const NvCodecContext nvcodecContext = NvCodecContextProvider::getNvCodecContext();
@@ -115,7 +131,10 @@ XprsResult enumDecoders(CodecList& codecs, bool hwCapabilityCheck) {
       }
     }
   } catch (std::exception& e) {
-    XR_LOGE("{}", convertExceptionToError(e, result));
+    // Downgraded from XR_LOGE: on non-GPU machines this fires every time a VRS
+    // file is opened (CUDA init throws). Callers fall back to SW decoders that
+    // were already collected before the throw, so this is expected, not an error.
+    XR_LOGW("HW decoder enumeration skipped: {}", convertExceptionToError(e, result));
   }
 
   // stable_sort so decoders with equal hwAccel keep their
@@ -137,11 +156,17 @@ enumDecodersByFormat(CodecList& codecs, VideoCodecFormat standard, bool hwCapabi
 
   codecs.clear();
   codecs.reserve(std::size(kPreferredDecoderImplementations));
+  const bool hwDisabled = isHwDecodeDisabled();
   try {
     for (const auto& impl : kPreferredDecoderImplementations) {
       VideoCodec codec;
       if (findDecoderByName(impl, codec)) {
         if (codec.format == standard) {
+          if (codec.hwAccel && hwDisabled) {
+            XR_LOGI(
+                "Skipping HW decoder {} (XPRS_DISABLE_HW_DECODE is set)", codec.implementationName);
+            continue;
+          }
           if (codec.hwAccel && hwCapabilityCheck) {
 #ifdef WITH_NVCODEC
             const NvCodecContext nvcodecContext = NvCodecContextProvider::getNvCodecContext();
@@ -159,7 +184,7 @@ enumDecodersByFormat(CodecList& codecs, VideoCodecFormat standard, bool hwCapabi
       }
     }
   } catch (std::exception& e) {
-    XR_LOGE("{}", convertExceptionToError(e, result));
+    XR_LOGW("HW decoder enumeration skipped: {}", convertExceptionToError(e, result));
   }
 
   // stable_sort so decoders with equal hwAccel keep their

--- a/xprs/xprsDecoder.cpp
+++ b/xprs/xprsDecoder.cpp
@@ -19,11 +19,11 @@
 // See xprsDecoder.h for details.
 
 #include "xprsDecoder.h"
-#ifdef WITH_NVCODEC
-#include "cudaContextProvider.h"
-#endif
-#ifdef WITH_NVCODEC
+
 #include "Codecs.h"
+#include "NvCodecConfig.h"
+#ifdef XPRS_HAS_NVDEC
+#include "cudaContextProvider.h"
 #endif
 #include "xprsUtils.h"
 
@@ -47,7 +47,7 @@ CVideoDecoder::~CVideoDecoder() = default;
 XprsResult CVideoDecoder::init(bool disableHwAcceleration) {
   XprsResult result = XprsResult::OK;
   try {
-#ifdef WITH_NVCODEC
+#ifdef XPRS_HAS_NVDEC
     if (implementationName == kNvH264DecoderName || implementationName == kNvH265DecoderName ||
         implementationName == kNvAv1DecoderName) {
       const NvCodecContext nvcodec_context = NvCodecContextProvider::getNvCodecContext();

--- a/xprs/xprsDecoder.cpp
+++ b/xprs/xprsDecoder.cpp
@@ -279,7 +279,11 @@ XprsResult CVideoDecoder::decodeFrame(Frame& frameOut, const Buffer& compressed)
       convertAVFrame(_pix.avFrame(), frameOut);
     }
   } catch (std::exception& e) {
-    XR_LOGE("{}", convertExceptionToError(e, result));
+    // WARNING, not ERROR: a decode exception here is recoverable — the error is
+    // returned via `result` and the caller (xprsDecoderMaker) falls back to the
+    // next decoder. The most common case is NVDEC rejecting an unsupported
+    // stream (e.g. monochrome H.265) during HW->SW probing.
+    XR_LOGW("{}", convertExceptionToError(e, result));
   }
 
   return result;

--- a/xprs/xprsDecoder.h
+++ b/xprs/xprsDecoder.h
@@ -22,7 +22,8 @@
 #include <memory>
 
 #include "FFmpegDecode.h"
-#ifdef WITH_NVCODEC
+#include "NvCodecConfig.h"
+#ifdef XPRS_HAS_NVDEC
 #include "nvDecoder.h"
 #endif
 #include "xprs.h"


### PR DESCRIPTION
Summary:

This is D1b in the GPU-accelerated H.265 decoding stack for projectaria-tools (plan v11 at ~/gdrive/plans/2026-04-03-gpu-accelerated-h265-decoding-pat-v11.md, tech design at https://docs.google.com/document/d/1TMeLy0TqvAdlYo0IY3Qm4BrzE8i035z9MzYvGl_CzeM/edit by Lou Yang).

Refactor only — no behavior change. Replaces 22 in-source `#ifdef WITH_NVCODEC` directives with self-documenting `XPRS_HAS_NVDEC` (decoder side) and `XPRS_HAS_NVENC` (encoder side) macros, defined by a new `NvCodecConfig.h` single-source-of-truth header. Build-system flags (`-DWITH_NVCODEC=1` in BUCK and CMake) remain as the upstream input.

Why split the macro: today both halves are gated together (`WITH_NVCODEC` is set or unset for both encoder and decoder). The split prepares for build configurations that ship only one half — most importantly the OSS PyPI wheel will want NVDEC without NVENC, since PyPI users typically want decode acceleration but the encode path requires hardware NVIDIA explicitly doesn't support across all SKUs (e.g., A100 has NVDEC but no NVENC). At the call site, `#ifdef XPRS_HAS_NVDEC` makes the intent clear in a way that `#ifdef WITH_NVCODEC` does not.

Files changed:
  NEW arvr/projects/compression/xprs/NvCodecConfig.h — defines XPRS_HAS_NVDEC + XPRS_HAS_NVENC under WITH_NVCODEC, with explanatory comment.
  arvr/projects/compression/xprs/Codecs.h — removed `#include "nvEncoder.h"` (its only consumers — xprsEncApi.cpp, xprsEncoder.cpp, xprs_gtest_common.h — already include nvEncoder.h directly). Adds an explanatory comment so the next reader doesn't re-add it.
  arvr/projects/compression/xprs/xprsDecApi.cpp — added `#include "NvCodecConfig.h"`, replaced 4× `WITH_NVCODEC` with `XPRS_HAS_NVDEC`.
  arvr/projects/compression/xprs/xprsDecoder.h — added include, swapped the nvDecoder.h gate to XPRS_HAS_NVDEC.
  arvr/projects/compression/xprs/xprsDecoder.cpp — added include, consolidated two redundant adjacent `#ifdef WITH_NVCODEC` blocks (one wrapping `cudaContextProvider.h`, one wrapping `Codecs.h` — Codecs.h was unconditionally needed and didn't actually need a guard), used XPRS_HAS_NVDEC.
  arvr/projects/compression/xprs/xprsEncApi.cpp — added include, replaced 6× `WITH_NVCODEC` with `XPRS_HAS_NVENC`, updated TODO comment to reference the new macro.
  arvr/projects/compression/xprs/xprsEncoder.cpp — added include, replaced 2× `WITH_NVCODEC` with `XPRS_HAS_NVENC`.
  arvr/projects/compression/xprs/test/xprs_gtest_codec.cpp — added include, replaced 1× `WITH_NVCODEC` with `XPRS_HAS_NVENC` (test exercises NV encoders by name).
  arvr/projects/compression/xprs/test/xprs_gtest_common.h — added include, replaced 2× `WITH_NVCODEC` with `XPRS_HAS_NVENC`.
  arvr/projects/compression/xprs/BUCK — added `NvCodecConfig.h` to `SUPPORTED_PLATFORMS_HEADERS` so it's exposed to consumers.

NOT changed (out of scope):
  arvr/projects/compression/xprs/CMakeLists.txt — has the existing `target_compile_options` instead of `target_compile_definitions` bug for ENABLE_NVCODEC; D2 fixes this.
  arvr/projects/compression/xprs/BUCK line 209 (`-DWITH_NVCODEC=1`) and the test BUCK / helpers.bzl equivalents — these are intentionally still WITH_NVCODEC since they pass the upstream flag that NvCodecConfig.h reads.
  arvr/projects/oatmeal/acro_conversion/test/BUCK (`-DWITH_NVCODEC=1`) — out-of-tree consumer, unchanged.

Reviewed By: PiotrBrzyski

Differential Revision: D103253723


