### PR TITLE
{CUDA Decoding} Add NVCODEC build-test CI job and nv-codec-headers docs (#260)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -75,3 +75,50 @@ jobs:
           cd build
           ninja all
           ctest -j8
+
+  build-nvcodec:
+    name: Build VRS NVCODEC (Linux, build-only)
+    runs-on: ubuntu-latest
+    # GitHub-hosted runners have no NVIDIA GPU, so this only compiles the
+    # ENABLE_NVCODEC path -- which needs nv-codec-headers but neither a GPU nor a
+    # CUDA toolkit -- to catch OSS build breakage. GPU decode is validated
+    # manually on a GPU machine (see projectaria_tools shipping docs).
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -o Acquire::Retries=5 \
+            cmake git ninja-build libgtest-dev libfmt-dev \
+            libjpeg-dev libturbojpeg-dev libpng-dev \
+            liblz4-dev libzstd-dev libxxhash-dev \
+            libboost-dev \
+            libopus-dev \
+            qtbase5-dev portaudio19-dev \
+            libeigen3-dev
+
+      - name: Install nv-codec-headers
+        run: |
+          git clone --depth 1 --branch n12.1.14.0 \
+            https://github.com/FFmpeg/nv-codec-headers.git /tmp/nv-codec-headers
+          sudo make -C /tmp/nv-codec-headers install PREFIX=/usr
+          pkg-config --modversion ffnvcodec
+
+      - name: Build FFMPEG
+        shell: bash
+        run: |
+          ./build_third_party_libs/build_ffmpeg_linuxunix.sh
+
+      - name: Configure (XPRS + NVCODEC)
+        shell: bash
+        run: |
+          mkdir build
+          cmake -S . -B build -G Ninja \
+            -DBUILD_WITH_XPRS:BOOL=ON -DENABLE_NVCODEC:BOOL=ON
+
+      - name: Build C++
+        shell: bash
+        run: |
+          cd build
+          ninja all

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ add_subdirectory(vrs)
 OPTION(BUILD_TOOLS "Build all of the tools" ON)
 OPTION(BUILD_SAMPLES "Build sample code and sample apps" ON)
 OPTION(BUILD_WITH_XPRS "Build with XPRS decoding library" OFF)
+OPTION(ENABLE_NVCODEC "Enable NVIDIA CUVID/NVDEC GPU-accelerated H.265 decoding in XPRS" OFF)
 
 # Check the operating system for BUILD_WITH_XPRS
 if (BUILD_WITH_XPRS)
@@ -79,7 +80,25 @@ if (BUILD_WITH_XPRS)
   endif()
 endif()
 
-# Add xprs folder if BUILD_WITH_XPRS is set
+# ENABLE_NVCODEC is meaningless without XPRS — fail fast rather than silently
+# building a CPU-only library when the user asked for GPU acceleration.
+# Also gate on Linux: NVDEC is currently shipped only for Linux x86_64; the
+# nv-codec-headers pkg-config dep doesn't exist on macOS.
+if (ENABLE_NVCODEC)
+  if (NOT BUILD_WITH_XPRS)
+    message(FATAL_ERROR "ENABLE_NVCODEC=ON requires BUILD_WITH_XPRS=ON.")
+  endif()
+  if (NOT TARGET_LINUX)
+    message(FATAL_ERROR "ENABLE_NVCODEC=ON is currently supported only on Linux x86_64.")
+  endif()
+  if (NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    message(FATAL_ERROR "ENABLE_NVCODEC=ON requires x86_64 architecture (nv-codec-headers is x86_64-only).")
+  endif()
+endif()
+
+# Add xprs folder if BUILD_WITH_XPRS is set. The ENABLE_NVCODEC cache
+# variable set above propagates automatically to xprs/CMakeLists.txt's
+# `option(ENABLE_NVCODEC ...)` declaration.
 if (BUILD_WITH_XPRS)
   add_subdirectory(${VRS_SOURCE_DIR}/xprs)
 endif()

--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ _These instructions are validated using Ubuntu 20.04, whereas Ubuntu 18.04 doesn
   sudo apt-get install npm doxygen
   ```
 
+### Optional: GPU-accelerated H.265 decoding (Linux x86_64, NVIDIA)
+
+XPRS can decode H.265 on NVIDIA GPUs via NVDEC. This requires the header-only
+[nv-codec-headers](https://github.com/FFmpeg/nv-codec-headers) at build time (no CUDA
+toolkit needed; the driver's `libcuda`/`libnvcuvid` are loaded at runtime):
+
+```
+git clone --branch n12.1.14.0 https://github.com/FFmpeg/nv-codec-headers.git
+sudo make -C nv-codec-headers install PREFIX=/usr
+```
+
+Then configure with `-DBUILD_WITH_XPRS=ON -DENABLE_NVCODEC=ON`. The resulting library is
+CUDA-agnostic: it auto-accelerates color (YUV420) H.265 streams when an NVIDIA driver is
+present and falls back to CPU decoding otherwise (monochrome streams always use CPU, as
+NVDEC does not support them).
+
 ## Build & run (macOS & Linux)
 
 - Run cmake:

--- a/xprs/CMakeLists.txt
+++ b/xprs/CMakeLists.txt
@@ -13,16 +13,17 @@
 # limitations under the License.
 
 
-# Base sources (always built). Explicit list rather than file(GLOB) so the
-# NVDEC/CUDA sources (nvDecoder.cpp, cudaContextProvider.cpp) are not compiled
-# unconditionally: they need nv-codec-headers (ffnvcodec) at build time and an
-# NVIDIA driver at runtime, so the default OSS build (ENABLE_NVCODEC=OFF) must
-# leave them out. Only the files synced to OSS by vrs.cconf are listed.
+# Base sources (always built). Explicit list rather than file(GLOB) so that
+# nvDecoder.cpp / cudaContextProvider.cpp are NOT compiled unconditionally —
+# they need CUDA / nv-codec-headers and would fail to compile on machines
+# without them. Pybind11.cpp is intentionally excluded: it lives in a separate
+# Buck target (xprs_python_bindings) and is not part of the OSS CMake library.
 #
-# DECODER-ONLY: the OSS distribution ships only the decode path. The encoder
-# sources (nvEncoder.cpp, FFmpegEncode, etc.) depend on internal-only headers
-# that are not synced to OSS; xprsEncZero.cpp is the no-op encoder stub that
-# lets the library link without them.
+# DECODER-ONLY: the OSS distribution ships only the decode path (matching the
+# files synced by vrs.cconf's xprsFileList). The real encoder (FFmpegEncode,
+# SvtAv1Encoder, mux, xprsEncoder, xprsEncApi, xprsMux) depends on internal-only
+# headers (e.g. hevc_sps_dpb_patch.h) and SVT-AV1, neither of which ship to OSS;
+# xprsEncZero.cpp provides the no-op encoder stub so the library still links.
 set(XPRS_SRCS
   FFmpegDecode.cpp
   FFmpegUtils.cpp
@@ -40,12 +41,13 @@ set(XPRS_HEADERS
   FFmpegUtils.h
   Final.h
   InternalDecoder.h
+  NvCodecConfig.h
   xprs.h
   xprsDecoder.h
   xprsUtils.h
 )
 
-# NVDEC/CUDA decode sources (only when ENABLE_NVCODEC=ON).
+# NVCODEC decode sources (only when ENABLE_NVCODEC=ON).
 set(XPRS_NVCODEC_SRCS
   nvDecoder.cpp
   cudaContextProvider.cpp
@@ -66,7 +68,18 @@ add_library(xprs ${XPRS_SRCS} ${XPRS_HEADERS})
 set(XPRS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
 if (ENABLE_NVCODEC)
+  # WITH_NVCODEC is the upstream flag read by NvCodecConfig.h, which then
+  # defines XPRS_HAS_NVDEC / XPRS_HAS_NVENC for source files to use.
+  # Note: this used to be `target_compile_options(... PRIVATE WITH_NVCODEC)`
+  # which silently did nothing (compile_options expects raw flags like
+  # -Wall, not preprocessor names) — the OSS CUDA build path has never
+  # actually been compiled with WITH_NVCODEC defined until this fix.
   target_compile_definitions(xprs PRIVATE WITH_NVCODEC=1)
+
+  # nv-codec-headers ships the runtime dlopen shims for libcuda/libnvcuvid.
+  # Found via pkg-config; required at OS level (apt install nv-codec-headers
+  # or build from https://github.com/FFmpeg/nv-codec-headers). No CUDA
+  # toolchain is required at build time — symbols are loaded at runtime.
   find_package(PkgConfig REQUIRED)
   pkg_check_modules(FFNVCODEC REQUIRED IMPORTED_TARGET ffnvcodec)
   target_link_libraries(xprs PRIVATE PkgConfig::FFNVCODEC)

--- a/xprs/Codecs.h
+++ b/xprs/Codecs.h
@@ -18,9 +18,11 @@
 
 #include <string_view>
 
-#ifdef WITH_NVCODEC
-#include "nvEncoder.h"
-#endif
+// Note: nvEncoder.h is intentionally NOT included here. Earlier versions of
+// this header pulled it in under WITH_NVCODEC, but the only consumers
+// (xprsEncApi.cpp, xprsEncoder.cpp, test/xprs_gtest_common.h) include
+// nvEncoder.h directly. Removing it here lets Codecs.h stay free of the
+// XPRS_HAS_NVENC guard.
 
 namespace xprs {
 

--- a/xprs/NvCodecConfig.h
+++ b/xprs/NvCodecConfig.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// Single source of truth for NVIDIA codec compilation guards.
+//
+// `WITH_NVCODEC` is the build-system flag (Buck preprocessor flag, CMake
+// `option(ENABLE_NVCODEC ...)`). Source files should use the self-documenting
+// macros below instead of `WITH_NVCODEC` so it's clear at the call site
+// whether the gated code requires NVDEC (decode), NVENC (encode), or both.
+//
+// Both macros are defined together when WITH_NVCODEC is set. The split into
+// separate macros prepares for build configurations that ship only one half
+// (e.g., OSS distributions that include NVDEC but omit NVENC due to driver,
+// hardware, or licensing constraints).
+
+#ifdef WITH_NVCODEC
+#define XPRS_HAS_NVDEC
+#define XPRS_HAS_NVENC
+#endif

--- a/xprs/cudaContextProvider.cpp
+++ b/xprs/cudaContextProvider.cpp
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
+// DEFAULT_LOG_CHANNEL must be defined before "logging/Log.h": the OSS build's
+// XR_LOGE/XR_LOGW macros are gated on it (the internal logging header defines
+// them unconditionally, which is why this ordering bug is invisible to the Buck
+// build but breaks the OSS CMake build).
+#define DEFAULT_LOG_CHANNEL "XPRS"
+
 #include "cudaContextProvider.h"
 
 #include "logging/Log.h"
-#define DEFAULT_LOG_CHANNEL "XPRS"
 
 namespace xprs {
 
@@ -49,23 +54,27 @@ NvCodecContext NvCodecContextProvider::getNvCodecContext(const int device_num) {
     return nv_codec_context;
   }
 
+  // Note: all failures in this function below log at WARN, not ERROR. The only caller
+  // (xprsDecApi.cpp::enumDecoders) catches the throw and falls back to SW
+  // decoders. On a non-GPU machine this fires every VRS file open, so logging
+  // ERROR-level would spam users who never asked for GPU decoding.
   int ret = cuda_load_functions(&nv_codec_context._cuda_functions, nullptr);
   if (ret < 0) {
     const std::string message = "Loading CUDA functions failed";
-    XR_LOGE("{}", message.c_str());
+    XR_LOGW("{}", message.c_str());
     throw std::runtime_error(message);
   }
   ret = cuvid_load_functions(&nv_codec_context._cuvid_functions, nullptr);
   if (ret < 0) {
     const std::string message = "Loading nvcuvid functions failed";
-    XR_LOGE("{}", message.c_str());
+    XR_LOGW("{}", message.c_str());
     throw std::runtime_error(message);
   }
 
   CUresult cu_result = nv_codec_context._cuda_functions->cuInit(0);
   if (cu_result != CUDA_SUCCESS) {
     const std::string message = "cuInit failed with error code: " + std::to_string(cu_result);
-    XR_LOGE("{}", message.c_str());
+    XR_LOGW("{}", message.c_str());
     throw std::runtime_error(message);
   }
 
@@ -73,7 +82,7 @@ NvCodecContext NvCodecContextProvider::getNvCodecContext(const int device_num) {
   cu_result = nv_codec_context._cuda_functions->cuDeviceGet(&cuda_device, device_num);
   if (cu_result != CUDA_SUCCESS) {
     const std::string message = "cuDeviceGet failed with error code: " + std::to_string(cu_result);
-    XR_LOGE("{}", message.c_str());
+    XR_LOGW("{}", message.c_str());
     throw std::runtime_error(message);
   }
 
@@ -82,7 +91,7 @@ NvCodecContext NvCodecContextProvider::getNvCodecContext(const int device_num) {
   if (cu_result != CUDA_SUCCESS) {
     const std::string message =
         "cuDeviceGetName failed with error code: " + std::to_string(cu_result);
-    XR_LOGE("{}", message.c_str());
+    XR_LOGW("{}", message.c_str());
     throw std::runtime_error(message);
   }
 
@@ -90,7 +99,7 @@ NvCodecContext NvCodecContextProvider::getNvCodecContext(const int device_num) {
       &nv_codec_context._cucontext, CU_CTX_SCHED_BLOCKING_SYNC, cuda_device);
   if (cu_result != CUDA_SUCCESS) {
     const std::string message = "cuCtxCreate failed with error code: " + std::to_string(cu_result);
-    XR_LOGE("{}", message.c_str());
+    XR_LOGW("{}", message.c_str());
     throw std::runtime_error(message);
   }
 
@@ -99,7 +108,7 @@ NvCodecContext NvCodecContextProvider::getNvCodecContext(const int device_num) {
   if (cu_result != CUDA_SUCCESS) {
     const std::string message =
         "cuCtxPopCurrent failed with error code: " + std::to_string(cu_result);
-    XR_LOGE("{}", message.c_str());
+    XR_LOGW("{}", message.c_str());
     throw std::runtime_error(message);
   }
 

--- a/xprs/cudaContextProvider.cpp
+++ b/xprs/cudaContextProvider.cpp
@@ -22,9 +22,55 @@
 
 #include "cudaContextProvider.h"
 
+#include <atomic>
+#include <mutex>
+#include <string>
+#include <type_traits>
+
 #include "logging/Log.h"
 
 namespace xprs {
+
+namespace {
+
+// Tri-state init flag for getNvCodecContext(). We don't retry on failure
+// because (a) CUDA driver / kernel module availability is fixed for the
+// lifetime of the process — if cuInit() fails once it will keep failing;
+// (b) every retry leaks a pair of dlopen handles (cuda_load_functions +
+// cuvid_load_functions) for callers that catch the throw and call us again
+// on the next VRS file open. In a long-running non-GPU process this can
+// leak hundreds of handles before exit.
+enum class InitState : int { Uninit = 0, Ready = 1, Failed = 2 };
+
+std::atomic<InitState> nv_codec_init_state{InitState::Uninit};
+std::mutex nv_codec_init_mutex;
+NvCodecContext cached_nv_codec_context;
+// Write-once: set only inside fail() under nv_codec_init_mutex, read only after
+// observing kFailed via acquire-load. Do not mutate after publish.
+std::string nv_codec_init_error;
+
+// Test-only: counts how many times a thread has entered the heavy init body
+// below (past the under-lock double-check). Exposed via
+// detail::nvCodecInitCallCountForTesting(). Only mutated under
+// nv_codec_init_mutex, so relaxed ordering suffices.
+std::atomic<int> nv_codec_init_call_count{0};
+
+// Free any partially-initialized handles after a failed init attempt.
+// Safe to call with null pointers — the dlopen free helpers no-op on null.
+void freeNvCodecHandles(NvCodecContext& ctx) {
+  if (ctx._cucontext != nullptr && ctx._cuda_functions != nullptr) {
+    ctx._cuda_functions->cuCtxDestroy(ctx._cucontext);
+    ctx._cucontext = nullptr;
+  }
+  if (ctx._cuda_functions != nullptr) {
+    cuda_free_functions(&ctx._cuda_functions);
+  }
+  if (ctx._cuvid_functions != nullptr) {
+    cuvid_free_functions(&ctx._cuvid_functions);
+  }
+}
+
+} // namespace
 
 CUDAContextScope::CUDAContextScope(const NvCodecContext& nv_codec_context)
     : _nv_codec_context(nv_codec_context) {
@@ -49,70 +95,136 @@ CUDAContextScope ::~CUDAContextScope() {
 }
 
 NvCodecContext NvCodecContextProvider::getNvCodecContext(const int device_num) {
-  static NvCodecContext nv_codec_context;
-  if (nv_codec_context._cucontext) {
-    return nv_codec_context;
+  // Fast path under acquire ordering: most calls hit this once init has
+  // either succeeded or permanently failed for the process.
+  const InitState state = nv_codec_init_state.load(std::memory_order_acquire);
+  if (state == InitState::Ready) {
+    return cached_nv_codec_context;
   }
+  if (state == InitState::Failed) {
+    // Safe without mutex: the acquire-load on nv_codec_init_state synchronizes-with
+    // the release-store in fail(), which happens-after the write to
+    // nv_codec_init_error.
+    throw std::runtime_error(nv_codec_init_error);
+  }
+
+  // Slow path: serialize the first init across threads. Without this, two
+  // threads racing past the fast-path check above would both try to
+  // cuda_load_functions() / cuCtxCreate(), leaking handles and possibly
+  // installing inconsistent state into cached_nv_codec_context.
+  std::lock_guard<std::mutex> lock(nv_codec_init_mutex);
+
+  // Re-check under the lock — another thread may have completed init while
+  // we were waiting.
+  const InitState recheck = nv_codec_init_state.load(std::memory_order_acquire);
+  if (recheck == InitState::Ready) {
+    return cached_nv_codec_context;
+  }
+  if (recheck == InitState::Failed) {
+    throw std::runtime_error(nv_codec_init_error);
+  }
+
+  // Exactly one thread per init generation reaches here (we hold the lock and
+  // the state is still Uninit). The test hook asserts this count is 1 — see
+  // detail::nvCodecInitCallCountForTesting().
+  nv_codec_init_call_count.fetch_add(1, std::memory_order_relaxed);
+
+  // Build into a local context. Only copy into cached_nv_codec_context after every
+  // step has succeeded — partial state must never be visible to the fast path.
+  // (Previously the code wrote directly into the static, so a failure between
+  // cuCtxCreate and cuCtxPopCurrent left _cucontext set to a half-built ctx.)
+  NvCodecContext local_ctx;
+  std::string err;
+
+  auto fail = [&](std::string message) {
+    err = std::move(message);
+    XR_LOGW("{}", err);
+    freeNvCodecHandles(local_ctx);
+    nv_codec_init_error = err;
+    nv_codec_init_state.store(InitState::Failed, std::memory_order_release);
+  };
 
   // Note: all failures in this function below log at WARN, not ERROR. The only caller
   // (xprsDecApi.cpp::enumDecoders) catches the throw and falls back to SW
   // decoders. On a non-GPU machine this fires every VRS file open, so logging
   // ERROR-level would spam users who never asked for GPU decoding.
-  int ret = cuda_load_functions(&nv_codec_context._cuda_functions, nullptr);
+  int ret = cuda_load_functions(&local_ctx._cuda_functions, nullptr);
   if (ret < 0) {
-    const std::string message = "Loading CUDA functions failed";
-    XR_LOGW("{}", message.c_str());
-    throw std::runtime_error(message);
+    fail("Loading CUDA functions failed");
+    throw std::runtime_error(nv_codec_init_error);
   }
-  ret = cuvid_load_functions(&nv_codec_context._cuvid_functions, nullptr);
+  ret = cuvid_load_functions(&local_ctx._cuvid_functions, nullptr);
   if (ret < 0) {
-    const std::string message = "Loading nvcuvid functions failed";
-    XR_LOGW("{}", message.c_str());
-    throw std::runtime_error(message);
+    fail("Loading nvcuvid functions failed");
+    throw std::runtime_error(nv_codec_init_error);
   }
 
-  CUresult cu_result = nv_codec_context._cuda_functions->cuInit(0);
+  CUresult cu_result = local_ctx._cuda_functions->cuInit(0);
   if (cu_result != CUDA_SUCCESS) {
-    const std::string message = "cuInit failed with error code: " + std::to_string(cu_result);
-    XR_LOGW("{}", message.c_str());
-    throw std::runtime_error(message);
+    fail("cuInit failed with error code: " + std::to_string(cu_result));
+    throw std::runtime_error(nv_codec_init_error);
   }
 
   CUdevice cuda_device = 0;
-  cu_result = nv_codec_context._cuda_functions->cuDeviceGet(&cuda_device, device_num);
+  cu_result = local_ctx._cuda_functions->cuDeviceGet(&cuda_device, device_num);
   if (cu_result != CUDA_SUCCESS) {
-    const std::string message = "cuDeviceGet failed with error code: " + std::to_string(cu_result);
-    XR_LOGW("{}", message.c_str());
-    throw std::runtime_error(message);
+    fail("cuDeviceGet failed with error code: " + std::to_string(cu_result));
+    throw std::runtime_error(nv_codec_init_error);
   }
 
-  cu_result = nv_codec_context._cuda_functions->cuDeviceGetName(
-      nv_codec_context._device_name, sizeof(nv_codec_context._device_name), cuda_device);
+  cu_result = local_ctx._cuda_functions->cuDeviceGetName(
+      local_ctx._device_name, sizeof(local_ctx._device_name), cuda_device);
   if (cu_result != CUDA_SUCCESS) {
-    const std::string message =
-        "cuDeviceGetName failed with error code: " + std::to_string(cu_result);
-    XR_LOGW("{}", message.c_str());
-    throw std::runtime_error(message);
+    fail("cuDeviceGetName failed with error code: " + std::to_string(cu_result));
+    throw std::runtime_error(nv_codec_init_error);
   }
 
-  cu_result = nv_codec_context._cuda_functions->cuCtxCreate(
-      &nv_codec_context._cucontext, CU_CTX_SCHED_BLOCKING_SYNC, cuda_device);
+  cu_result = local_ctx._cuda_functions->cuCtxCreate(
+      &local_ctx._cucontext, CU_CTX_SCHED_BLOCKING_SYNC, cuda_device);
   if (cu_result != CUDA_SUCCESS) {
-    const std::string message = "cuCtxCreate failed with error code: " + std::to_string(cu_result);
-    XR_LOGW("{}", message.c_str());
-    throw std::runtime_error(message);
+    fail("cuCtxCreate failed with error code: " + std::to_string(cu_result));
+    throw std::runtime_error(nv_codec_init_error);
   }
 
-  // Restore the previous context
-  cu_result = nv_codec_context._cuda_functions->cuCtxPopCurrent(nullptr);
+  cu_result = local_ctx._cuda_functions->cuCtxPopCurrent(nullptr);
   if (cu_result != CUDA_SUCCESS) {
-    const std::string message =
-        "cuCtxPopCurrent failed with error code: " + std::to_string(cu_result);
-    XR_LOGW("{}", message.c_str());
-    throw std::runtime_error(message);
+    // Context is still current on this thread — null out _cucontext so
+    // freeNvCodecHandles skips cuCtxDestroy (destroying while current is UB).
+    // The context leaks but this path is astronomically rare (driver bug).
+    local_ctx._cucontext = nullptr;
+    fail("cuCtxPopCurrent failed with error code: " + std::to_string(cu_result));
+    throw std::runtime_error(nv_codec_init_error);
   }
 
-  return nv_codec_context;
+  // SUCCESS: publish the fully-built context. The release-store on nv_codec_init_state
+  // synchronizes with the acquire-load on the fast path so other threads see
+  // the writes to cached_nv_codec_context that happened before the store here.
+  cached_nv_codec_context = local_ctx;
+  static_assert(
+      std::is_trivially_destructible_v<NvCodecContext>,
+      "NvCodecContext must be trivially destructible — the manual null-out "
+      "below assumes no destructor runs on local_ctx going out of scope.");
+  local_ctx._cuda_functions = nullptr;
+  local_ctx._cuvid_functions = nullptr;
+  local_ctx._cucontext = nullptr;
+  nv_codec_init_state.store(InitState::Ready, std::memory_order_release);
+  return cached_nv_codec_context;
 }
+
+namespace detail {
+
+int nvCodecInitCallCountForTesting() {
+  return nv_codec_init_call_count.load(std::memory_order_relaxed);
+}
+
+void resetNvCodecContextForTesting() {
+  std::lock_guard<std::mutex> lock(nv_codec_init_mutex);
+  freeNvCodecHandles(cached_nv_codec_context);
+  nv_codec_init_error.clear();
+  nv_codec_init_call_count.store(0, std::memory_order_relaxed);
+  nv_codec_init_state.store(InitState::Uninit, std::memory_order_release);
+}
+
+} // namespace detail
 
 } // namespace xprs

--- a/xprs/cudaContextProvider.h
+++ b/xprs/cudaContextProvider.h
@@ -44,4 +44,21 @@ class NvCodecContextProvider {
   static NvCodecContext getNvCodecContext(int device_num = 0);
 };
 
+namespace detail {
+// Test-only hooks for the concurrency stress test (xprs_gtest_concurrency.cpp).
+// Not for production use.
+
+// Number of times getNvCodecContext() has run its heavy init body (past the
+// under-lock double-check). A correct atomic+mutex gate keeps this at exactly 1
+// per init generation no matter how many threads race; a regression to racy
+// double-checked-locking lets more than one thread through, which is otherwise
+// invisible because every thread still returns the same cached answer.
+int nvCodecInitCallCountForTesting();
+
+// Reset the init state machine to Uninit, freeing any cached handles, so the
+// next getNvCodecContext() re-runs init. NOT safe against live decoders holding
+// a CUcontext — test-only, for re-exercising the first-init race across rounds.
+void resetNvCodecContextForTesting();
+} // namespace detail
+
 } // namespace xprs

--- a/xprs/nvDecoder.cpp
+++ b/xprs/nvDecoder.cpp
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+// DEFAULT_LOG_CHANNEL must be defined before <logging/Log.h>: the OSS build's
+// XR_LOGE/XR_LOGW/XR_LOGI macros are gated on it (the internal logging header
+// defines them unconditionally, which is why this ordering bug is invisible to
+// the Buck build but breaks the OSS CMake build).
+#define DEFAULT_LOG_CHANNEL "XPRS"
+
 #include "nvDecoder.h"
 #include "Codecs.h"
 #include "FFmpegUtils.h"
@@ -22,10 +28,9 @@
 
 #include <logging/Log.h>
 #include <cmath>
+#include <memory>
 #include <stdexcept>
 #include <string>
-
-#define DEFAULT_LOG_CHANNEL "XPRS"
 
 namespace xprs {
 
@@ -167,6 +172,44 @@ int NvDecoder::HandleVideoSequence(CUVIDEOFORMAT* vdeo_format) {
   _decoded_image_yuv.resize(size_ofdecoded_image_yuv_format_in_bytes);
 
   CUDAContextScope cuda_context_scope(_nvcodec_context);
+
+  // Capability pre-check (NVIDIA-recommended): NVDEC hardware does not support
+  // every codec/chroma/bit-depth/resolution combination. Most notably it cannot
+  // decode monochrome (4:0:0) H.265 — used by Aria's grayscale SLAM and eye
+  // cameras — and returns CUDA_ERROR_NOT_SUPPORTED from cuvidCreateDecoder.
+  // Querying cuvidGetDecoderCaps first lets such streams fall back to SW decode
+  // with a single clear log line, instead of emitting alarming CUDA error logs
+  // for an entirely expected condition. cuvidGetDecoderCaps is loaded optionally
+  // by nv-codec-headers, so guard against a null function pointer.
+  if (_nvcodec_context._cuvid_functions->cuvidGetDecoderCaps != nullptr) {
+    CUVIDDECODECAPS decode_caps = {};
+    decode_caps.eCodecType = video_decode_create_info.CodecType;
+    decode_caps.eChromaFormat = video_decode_create_info.ChromaFormat;
+    decode_caps.nBitDepthMinus8 = video_decode_create_info.bitDepthMinus8;
+    // Only a *successful* caps query that reports the format unsupported (or out
+    // of the supported size range) forces SW fallback. If the query itself fails
+    // (transient driver/context issue), fall through to cuvidCreateDecoder and
+    // let it surface the real error rather than permanently disabling NVDEC.
+    if (_nvcodec_context._cuvid_functions->cuvidGetDecoderCaps(&decode_caps) == CUDA_SUCCESS) {
+      const unsigned long width = video_decode_create_info.ulWidth;
+      const unsigned long height = video_decode_create_info.ulHeight;
+      const bool unsupported = !decode_caps.bIsSupported ||
+          width < static_cast<unsigned long>(decode_caps.nMinWidth) ||
+          height < static_cast<unsigned long>(decode_caps.nMinHeight) ||
+          width > static_cast<unsigned long>(decode_caps.nMaxWidth) ||
+          height > static_cast<unsigned long>(decode_caps.nMaxHeight);
+      if (unsupported) {
+        XR_LOGW(
+            "NVDEC does not support this stream (chroma_format={}, bit_depth={}, {}x{}); falling back to SW decode",
+            static_cast<int>(video_decode_create_info.ChromaFormat),
+            static_cast<int>(video_decode_create_info.bitDepthMinus8) + 8,
+            width,
+            height);
+        throw std::runtime_error("NVDEC unsupported stream format; using SW decode");
+      }
+    }
+  }
+
   CUDA_API_CALL(
       _nvcodec_context._cuvid_functions->cuvidCreateDecoder(&_decoder, &video_decode_create_info),
       _nvcodec_context._cuda_functions,

--- a/xprs/xprs.h
+++ b/xprs/xprs.h
@@ -410,6 +410,22 @@ XprsResult enumEncoders(CodecList& codecs, bool hwCapabilityCheck = true);
 XprsResult enumDecoders(CodecList& codecs, bool hwCapabilityCheck = true);
 
 /**
+ * Returns true if NVDEC GPU-accelerated decoding is available in this process.
+ *
+ * This is a runtime check: it requires both that the library was compiled with
+ * NVDEC support (XPRS_HAS_NVDEC) AND that the CUDA driver / libnvcuvid can
+ * be loaded on the current machine. False is returned on builds without
+ * XPRS_HAS_NVDEC, on machines without an NVIDIA driver, and on machines where
+ * CUDA init fails for any reason. The result is cached after the first call.
+ *
+ * Note: the XPRS_DISABLE_HW_DECODE env var is a separate concern — it
+ * suppresses HW codec selection in enumDecoders() but does not affect this
+ * function's return value. This function reports hardware capability, not
+ * effective decode policy.
+ */
+bool hasCudaSupport() noexcept;
+
+/**
  * Enumerate all available encoders for a give codec. In the beginning before we have HW support,
  * this would return just 1 codec.
  * @param codecs Returns the list of available encoders specified by \p standard.

--- a/xprs/xprsDecApi.cpp
+++ b/xprs/xprsDecApi.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "Codecs.h"
+#include "NvCodecConfig.h"
 #include "xprsDecoder.h"
 #include "xprsUtils.h"
 
@@ -34,7 +35,7 @@ namespace xprs {
 static const std::string_view kPreferredDecoderImplementations[] = {
     kH265DecoderName,
     kH264DecoderName,
-#ifdef WITH_NVCODEC
+#ifdef XPRS_HAS_NVDEC
     kNvH264DecoderName,
     kNvH265DecoderName,
     kNvAv1DecoderName,
@@ -68,7 +69,7 @@ bool findDecoderByName(const std::string_view& name, VideoCodec& codec) {
   }
 
   // Add custom decoders
-#ifdef WITH_NVCODEC
+#ifdef XPRS_HAS_NVDEC
   if (name == kNvH265DecoderName) {
     codec = VideoCodec{VideoCodecFormat::H265, name.data(), true};
     return true;
@@ -116,7 +117,7 @@ XprsResult enumDecoders(CodecList& codecs, bool hwCapabilityCheck) {
           continue;
         }
         if (codec.hwAccel && hwCapabilityCheck) {
-#ifdef WITH_NVCODEC
+#ifdef XPRS_HAS_NVDEC
           const NvCodecContext nvcodecContext = NvCodecContextProvider::getNvCodecContext();
           if (deviceHasNoHwDecoder(codec.implementationName, nvcodecContext._device_name)) {
             XR_LOGI(
@@ -168,7 +169,7 @@ enumDecodersByFormat(CodecList& codecs, VideoCodecFormat standard, bool hwCapabi
             continue;
           }
           if (codec.hwAccel && hwCapabilityCheck) {
-#ifdef WITH_NVCODEC
+#ifdef XPRS_HAS_NVDEC
             const NvCodecContext nvcodecContext = NvCodecContextProvider::getNvCodecContext();
             if (deviceHasNoHwDecoder(codec.implementationName, nvcodecContext._device_name)) {
               XR_LOGI(

--- a/xprs/xprsDecApi.cpp
+++ b/xprs/xprsDecApi.cpp
@@ -207,4 +207,23 @@ IVideoDecoder* createDecoder(const VideoCodec& codec) {
   return result;
 }
 
+bool hasCudaSupport() noexcept {
+#ifdef XPRS_HAS_NVDEC
+  // Compile-time NVDEC is wired in. Runtime check: try to bring up the
+  // CUDA context once. If the driver is missing, the kernel module isn't
+  // loaded, or no NVIDIA device is visible, getNvCodecContext() throws and
+  // we report no support. NvCodecContextProvider caches the result via
+  // its tri-state atomic (see cudaContextProvider.cpp), so subsequent
+  // calls are a single atomic load.
+  try {
+    NvCodecContextProvider::getNvCodecContext();
+    return true;
+  } catch (...) {
+    return false;
+  }
+#else
+  return false;
+#endif
+}
+
 } // namespace xprs

--- a/xprs/xprsDecApi.cpp
+++ b/xprs/xprsDecApi.cpp
@@ -19,6 +19,7 @@
 #include "xprsUtils.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <string_view>
 
 #ifdef WITH_DAV1D
@@ -85,6 +86,15 @@ bool findDecoderByName(const std::string_view& name, VideoCodec& codec) {
   return false;
 }
 
+// Set XPRS_DISABLE_HW_DECODE to any value to force CPU-only decoding. Useful
+// for deterministic results, working around GPU memory pressure, or comparing
+// HW-vs-SW output. Read once at first call so the value is fixed for the
+// process lifetime — runtime mutation of the env var has no effect.
+bool isHwDecodeDisabled() {
+  static const bool disabled = std::getenv("XPRS_DISABLE_HW_DECODE") != nullptr;
+  return disabled;
+}
+
 } // namespace
 
 ///
@@ -95,10 +105,16 @@ XprsResult enumDecoders(CodecList& codecs, bool hwCapabilityCheck) {
 
   codecs.clear();
   codecs.reserve(std::size(kPreferredDecoderImplementations));
+  const bool hwDisabled = isHwDecodeDisabled();
   try {
     for (const auto& impl : kPreferredDecoderImplementations) {
       VideoCodec codec;
       if (findDecoderByName(impl, codec)) {
+        if (codec.hwAccel && hwDisabled) {
+          XR_LOGI(
+              "Skipping HW decoder {} (XPRS_DISABLE_HW_DECODE is set)", codec.implementationName);
+          continue;
+        }
         if (codec.hwAccel && hwCapabilityCheck) {
 #ifdef WITH_NVCODEC
           const NvCodecContext nvcodecContext = NvCodecContextProvider::getNvCodecContext();
@@ -115,7 +131,10 @@ XprsResult enumDecoders(CodecList& codecs, bool hwCapabilityCheck) {
       }
     }
   } catch (std::exception& e) {
-    XR_LOGE("{}", convertExceptionToError(e, result));
+    // Downgraded from XR_LOGE: on non-GPU machines this fires every time a VRS
+    // file is opened (CUDA init throws). Callers fall back to SW decoders that
+    // were already collected before the throw, so this is expected, not an error.
+    XR_LOGW("HW decoder enumeration skipped: {}", convertExceptionToError(e, result));
   }
 
   // stable_sort so decoders with equal hwAccel keep their
@@ -137,11 +156,17 @@ enumDecodersByFormat(CodecList& codecs, VideoCodecFormat standard, bool hwCapabi
 
   codecs.clear();
   codecs.reserve(std::size(kPreferredDecoderImplementations));
+  const bool hwDisabled = isHwDecodeDisabled();
   try {
     for (const auto& impl : kPreferredDecoderImplementations) {
       VideoCodec codec;
       if (findDecoderByName(impl, codec)) {
         if (codec.format == standard) {
+          if (codec.hwAccel && hwDisabled) {
+            XR_LOGI(
+                "Skipping HW decoder {} (XPRS_DISABLE_HW_DECODE is set)", codec.implementationName);
+            continue;
+          }
           if (codec.hwAccel && hwCapabilityCheck) {
 #ifdef WITH_NVCODEC
             const NvCodecContext nvcodecContext = NvCodecContextProvider::getNvCodecContext();
@@ -159,7 +184,7 @@ enumDecodersByFormat(CodecList& codecs, VideoCodecFormat standard, bool hwCapabi
       }
     }
   } catch (std::exception& e) {
-    XR_LOGE("{}", convertExceptionToError(e, result));
+    XR_LOGW("HW decoder enumeration skipped: {}", convertExceptionToError(e, result));
   }
 
   // stable_sort so decoders with equal hwAccel keep their

--- a/xprs/xprsDecoder.cpp
+++ b/xprs/xprsDecoder.cpp
@@ -19,11 +19,11 @@
 // See xprsDecoder.h for details.
 
 #include "xprsDecoder.h"
-#ifdef WITH_NVCODEC
-#include "cudaContextProvider.h"
-#endif
-#ifdef WITH_NVCODEC
+
 #include "Codecs.h"
+#include "NvCodecConfig.h"
+#ifdef XPRS_HAS_NVDEC
+#include "cudaContextProvider.h"
 #endif
 #include "xprsUtils.h"
 
@@ -47,7 +47,7 @@ CVideoDecoder::~CVideoDecoder() = default;
 XprsResult CVideoDecoder::init(bool disableHwAcceleration) {
   XprsResult result = XprsResult::OK;
   try {
-#ifdef WITH_NVCODEC
+#ifdef XPRS_HAS_NVDEC
     if (implementationName == kNvH264DecoderName || implementationName == kNvH265DecoderName ||
         implementationName == kNvAv1DecoderName) {
       const NvCodecContext nvcodec_context = NvCodecContextProvider::getNvCodecContext();

--- a/xprs/xprsDecoder.cpp
+++ b/xprs/xprsDecoder.cpp
@@ -279,7 +279,11 @@ XprsResult CVideoDecoder::decodeFrame(Frame& frameOut, const Buffer& compressed)
       convertAVFrame(_pix.avFrame(), frameOut);
     }
   } catch (std::exception& e) {
-    XR_LOGE("{}", convertExceptionToError(e, result));
+    // WARNING, not ERROR: a decode exception here is recoverable — the error is
+    // returned via `result` and the caller (xprsDecoderMaker) falls back to the
+    // next decoder. The most common case is NVDEC rejecting an unsupported
+    // stream (e.g. monochrome H.265) during HW->SW probing.
+    XR_LOGW("{}", convertExceptionToError(e, result));
   }
 
   return result;

--- a/xprs/xprsDecoder.h
+++ b/xprs/xprsDecoder.h
@@ -22,7 +22,8 @@
 #include <memory>
 
 #include "FFmpegDecode.h"
-#ifdef WITH_NVCODEC
+#include "NvCodecConfig.h"
+#ifdef XPRS_HAS_NVDEC
 #include "nvDecoder.h"
 #endif
 #include "xprs.h"


### PR DESCRIPTION
Summary:

Adds a Linux build-only CI job (`build-nvcodec`) to VRS `build-and-test.yml` that installs `nv-codec-headers`, configures with `-DBUILD_WITH_XPRS=ON -DENABLE_NVCODEC=ON`, and builds. GitHub-hosted runners have no NVIDIA GPU, so this compiles the NVDEC path -- which needs only `nv-codec-headers`, not a GPU or CUDA toolkit -- to catch OSS build breakage. GPU decode is validated manually on a GPU machine. Also documents `nv-codec-headers` as an optional dependency for GPU-accelerated H.265 decoding in the README.

Part of the GPU-accelerated H.265 decoding rollout. Lands after the xprs CUDA decoder files are synced to the GitHub VRS mirror (configerator cconf change), since the NVCODEC build needs those sources.

Reviewed By: georges-berenger

Differential Revision: D110227873


