### PR TITLE
{CUDA Decoding} Destroy existing NVDEC decoder before recreating on sequence re-signal

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -75,3 +75,50 @@ jobs:
           cd build
           ninja all
           ctest -j8
+
+  build-nvcodec:
+    name: Build VRS NVCODEC (Linux, build-only)
+    runs-on: ubuntu-latest
+    # GitHub-hosted runners have no NVIDIA GPU, so this only compiles the
+    # ENABLE_NVCODEC path -- which needs nv-codec-headers but neither a GPU nor a
+    # CUDA toolkit -- to catch OSS build breakage. GPU decode is validated
+    # manually on a GPU machine (see projectaria_tools shipping docs).
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -o Acquire::Retries=5 \
+            cmake git ninja-build libgtest-dev libfmt-dev \
+            libjpeg-dev libturbojpeg-dev libpng-dev \
+            liblz4-dev libzstd-dev libxxhash-dev \
+            libboost-dev \
+            libopus-dev \
+            qtbase5-dev portaudio19-dev \
+            libeigen3-dev
+
+      - name: Install nv-codec-headers
+        run: |
+          git clone --depth 1 --branch n12.1.14.0 \
+            https://github.com/FFmpeg/nv-codec-headers.git /tmp/nv-codec-headers
+          sudo make -C /tmp/nv-codec-headers install PREFIX=/usr
+          pkg-config --modversion ffnvcodec
+
+      - name: Build FFMPEG
+        shell: bash
+        run: |
+          ./build_third_party_libs/build_ffmpeg_linuxunix.sh
+
+      - name: Configure (XPRS + NVCODEC)
+        shell: bash
+        run: |
+          mkdir build
+          cmake -S . -B build -G Ninja \
+            -DBUILD_WITH_XPRS:BOOL=ON -DENABLE_NVCODEC:BOOL=ON
+
+      - name: Build C++
+        shell: bash
+        run: |
+          cd build
+          ninja all

--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ _These instructions are validated using Ubuntu 20.04, whereas Ubuntu 18.04 doesn
   sudo apt-get install npm doxygen
   ```
 
+### Optional: GPU-accelerated H.265 decoding (Linux x86_64, NVIDIA)
+
+XPRS can decode H.265 on NVIDIA GPUs via NVDEC. This requires the header-only
+[nv-codec-headers](https://github.com/FFmpeg/nv-codec-headers) at build time (no CUDA
+toolkit needed; the driver's `libcuda`/`libnvcuvid` are loaded at runtime):
+
+```
+git clone --branch n12.1.14.0 https://github.com/FFmpeg/nv-codec-headers.git
+sudo make -C nv-codec-headers install PREFIX=/usr
+```
+
+Then configure with `-DBUILD_WITH_XPRS=ON -DENABLE_NVCODEC=ON`. The resulting library is
+CUDA-agnostic: it auto-accelerates color (YUV420) H.265 streams when an NVIDIA driver is
+present and falls back to CPU decoding otherwise (monochrome streams always use CPU, as
+NVDEC does not support them).
+
 ## Build & run (macOS & Linux)
 
 - Run cmake:

--- a/xprs/nvDecoder.cpp
+++ b/xprs/nvDecoder.cpp
@@ -210,6 +210,18 @@ int NvDecoder::HandleVideoSequence(CUVIDEOFORMAT* vdeo_format) {
     }
   }
 
+  // HandleVideoSequence can fire again mid-stream on a new sequence header or
+  // format change (see header). Never overwrite a live decoder handle: that
+  // leaks the previous CUvideodecoder and leaves the parser driving a stale one.
+  // Destroy the existing decoder before creating its replacement.
+  if (_decoder != nullptr) {
+    CUDA_API_CALL(
+        _nvcodec_context._cuvid_functions->cuvidDestroyDecoder(_decoder),
+        _nvcodec_context._cuda_functions,
+        DO_NOT_THROW);
+    _decoder = nullptr;
+  }
+
   CUDA_API_CALL(
       _nvcodec_context._cuvid_functions->cuvidCreateDecoder(&_decoder, &video_decode_create_info),
       _nvcodec_context._cuda_functions,


### PR DESCRIPTION
Summary:
`NvDecoder::HandleVideoSequence` is the NVDEC parser's sequence callback and, as its own header doc notes, can fire again mid-stream on a new sequence header or format change. The body unconditionally called `cuvidCreateDecoder(&_decoder, ...)`, so on any re-invocation it overwrote `_decoder` with a fresh handle without destroying the previous one — leaking the old `CUvideodecoder` and leaving the parser driving a stale/duplicated decoder. This is the "returning stale decoder" issue raised in review on D103253728.

Fix: guard the create call. When `_decoder` is already non-null, `cuvidDestroyDecoder` it (and null it, so a subsequent create failure can't double-free in the destructor) before creating the replacement. Destroy-before-recreate is chosen over `cuvidReconfigureDecoder` for correctness and simplicity: Aria streams have constant format so re-signal is rare, making the recreate cost negligible; reconfigure (an in-place perf optimization bounded by the original ulMaxWidth/Height) can be a later change if a re-signaling workload ever needs it.

Follow-up to D103253728.

Reviewed By: georges-berenger

Differential Revision: D113848493


